### PR TITLE
 Update the dockerfile.python 1 by disabling Python bytecode generation 

### DIFF
--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -26,4 +26,9 @@ EXPOSE 8080
 
 ENV PYTHONUNBUFFERED=1
 
+#Prevent Python from writing .pyc files and __pycache__ folders to disk
+#Make the runtime faster
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
 CMD ["python", "-m", "v1.src.sensing.ws_server"]


### PR DESCRIPTION
his small change adds ENV PYTHONDONTWRITEBYTECODE=1 to the Dockerfile.
It stops Python from creating .pyc files and __pycache__ folders every time code runs inside the container. This keeps the filesystem cleaner, avoids pointless disk writes (especially useful with read-only mounts or tmpfs), reduces permission headaches.