### PR TITLE
docs: update changelog, user guide, and README for ADR-043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sensing server UI API completion (ADR-043)** — 14 fully-functional REST endpoints for model management, CSI recording, and training control
+  - Model CRUD: `GET /api/v1/models`, `GET /api/v1/models/active`, `POST /api/v1/models/load`, `POST /api/v1/models/unload`, `DELETE /api/v1/models/:id`, `GET /api/v1/models/lora/profiles`, `POST /api/v1/models/lora/activate`
+  - CSI recording: `GET /api/v1/recording/list`, `POST /api/v1/recording/start`, `POST /api/v1/recording/stop`, `DELETE /api/v1/recording/:id`
+  - Training control: `GET /api/v1/train/status`, `POST /api/v1/train/start`, `POST /api/v1/train/stop`
+  - Recording writes CSI frames to `.jsonl` files via tokio background task
+  - Model/recording directories scanned at startup, state managed via `Arc<RwLock<AppStateInner>>`
+- **25 real mobile tests** replacing `it.todo()` placeholders — 205 assertions covering components, services, stores, hooks, screens, and utils
 - **Project MERIDIAN (ADR-027)** — Cross-environment domain generalization for WiFi pose estimation (1,858 lines, 72 tests)
   - `HardwareNormalizer` — Catmull-Rom cubic interpolation resamples any hardware CSI to canonical 56 subcarriers; z-score + phase sanitization
   - `DomainFactorizer` + `GradientReversalLayer` — adversarial disentanglement of pose-relevant vs environment-specific features
@@ -23,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR-025: macOS CoreWLAN WiFi Sensing (ORCA)
 
 ### Fixed
+- **WebSocket "RECONNECTING" on Dashboard/Live Demo** — `sensingService.start()` now called on app init in `app.js` so WebSocket connects immediately instead of waiting for Sensing tab visit
+- **Mobile WebSocket port** — `ws.service.ts` `buildWsUrl()` uses same-origin port instead of hardcoded port 3001
+- **Mobile Jest config** — `testPathIgnorePatterns` no longer silently ignores the entire test directory
 - Removed synthetic byte counters from Python `MacosWifiCollector` — now reports `tx_bytes=0, rx_bytes=0` instead of fake incrementing values
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ All 5 ruvector crates integrated in workspace:
 - `ruvector-attention` → `model.rs` (apply_spatial_attention) + `bvp.rs`
 
 ### Architecture Decisions
-32 ADRs in `docs/adr/` (ADR-001 through ADR-032). Key ones:
+43 ADRs in `docs/adr/` (ADR-001 through ADR-043). Key ones:
 - ADR-014: SOTA signal processing (Accepted)
 - ADR-015: MM-Fi + Wi-Pose training datasets (Accepted)
 - ADR-016: RuVector training pipeline integration (Accepted — complete)
@@ -173,7 +173,7 @@ Active feature branch: `ruvsense-full-implementation` (PR #77)
 ## File Organization
 
 - NEVER save to root folder — use the directories below
-- `docs/adr/` — Architecture Decision Records (32 ADRs)
+- `docs/adr/` — Architecture Decision Records (43 ADRs)
 - `docs/ddd/` — Domain-Driven Design models
 - `rust-port/wifi-densepose-rs/crates/` — Rust workspace crates (15 crates)
 - `rust-port/wifi-densepose-rs/crates/wifi-densepose-signal/src/ruvsense/` — RuvSense multistatic modules (14 files)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker run -p 3000:3000 ruvnet/wifi-densepose:latest
 | [User Guide](docs/user-guide.md) | Step-by-step guide: installation, first run, API usage, hardware setup, training |
 | [WiFi-Mat User Guide](docs/wifi-mat-user-guide.md) | Disaster response module: search & rescue, START triage |
 | [Build Guide](docs/build-guide.md) | Building from source (Rust and Python) |
-| [Architecture Decisions](docs/adr/) | 41 ADRs covering signal processing, training, hardware, security, domain generalization, multistatic sensing, CRV signal-line integration, edge intelligence |
+| [Architecture Decisions](docs/adr/) | 43 ADRs covering signal processing, training, hardware, security, domain generalization, multistatic sensing, CRV signal-line integration, edge intelligence, WASM edge modules, UI API completion |
 | [DDD Domain Model](docs/ddd/ruvsense-domain-model.md) | RuvSense bounded contexts, aggregates, domain events, and ubiquitous language |
 
 ---

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -301,6 +301,20 @@ Base URL: `http://localhost:3000` (Docker) or `http://localhost:8080` (binary de
 | `GET` | `/api/v1/model/layers` | Progressive model loading status | Layer A/B/C load state |
 | `GET` | `/api/v1/model/sona/profiles` | SONA adaptation profiles | List of environment profiles |
 | `POST` | `/api/v1/model/sona/activate` | Activate a SONA profile for a specific room | `{"profile":"kitchen"}` |
+| `GET` | `/api/v1/models` | List available RVF model files | `{"models":[...],"count":0}` |
+| `GET` | `/api/v1/models/active` | Currently loaded model (or null) | `{"model":null}` |
+| `POST` | `/api/v1/models/load` | Load a model by ID | `{"status":"loaded","model_id":"..."}` |
+| `POST` | `/api/v1/models/unload` | Unload the active model | `{"status":"unloaded"}` |
+| `DELETE` | `/api/v1/models/:id` | Delete a model file from disk | `{"status":"deleted"}` |
+| `GET` | `/api/v1/models/lora/profiles` | List LoRA adapter profiles | `{"profiles":[]}` |
+| `POST` | `/api/v1/models/lora/activate` | Activate a LoRA profile | `{"status":"activated"}` |
+| `GET` | `/api/v1/recording/list` | List CSI recording sessions | `{"recordings":[...],"count":0}` |
+| `POST` | `/api/v1/recording/start` | Start recording CSI frames to JSONL | `{"status":"recording","session_id":"..."}` |
+| `POST` | `/api/v1/recording/stop` | Stop the active recording | `{"status":"stopped","duration_secs":...}` |
+| `DELETE` | `/api/v1/recording/:id` | Delete a recording file | `{"status":"deleted"}` |
+| `GET` | `/api/v1/train/status` | Training run status | `{"phase":"idle"}` |
+| `POST` | `/api/v1/train/start` | Start a training run | `{"status":"started"}` |
+| `POST` | `/api/v1/train/stop` | Stop the active training run | `{"status":"stopped"}` |
 
 ### Example: Get Vital Signs
 
@@ -347,7 +361,9 @@ curl -s http://localhost:3000/api/v1/pose/current | python -m json.tool
 
 Real-time sensing data is available via WebSocket.
 
-**URL:** `ws://localhost:3001/ws/sensing` (Docker) or `ws://localhost:8765/ws/sensing` (binary default).
+**URL:** `ws://localhost:3000/ws/sensing` (same port as HTTP — recommended) or `ws://localhost:3001/ws/sensing` (dedicated WS port).
+
+> **Note:** The `/ws/sensing` WebSocket endpoint is available on both the HTTP port (3000) and the dedicated WebSocket port (3001/8765). The web UI uses the HTTP port so only one port needs to be exposed. The dedicated WS port remains available for backward compatibility.
 
 ### Python Example
 
@@ -812,7 +828,7 @@ The Rust implementation (v2) is 810x faster than Python (v1) for the full CSI pi
 
 ## Further Reading
 
-- [Architecture Decision Records](../docs/adr/) - 33 ADRs covering all design decisions
+- [Architecture Decision Records](../docs/adr/) - 43 ADRs covering all design decisions
 - [WiFi-Mat Disaster Response Guide](wifi-mat-user-guide.md) - Search & rescue module
 - [Build Guide](build-guide.md) - Detailed build instructions
 - [RuVector](https://github.com/ruvnet/ruvector) - Signal intelligence crate ecosystem


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Add ADR-043 entries — 14 new API endpoints, WebSocket connectivity fix, mobile WS port fix, Jest config fix, 25 real mobile tests
- **README.md**: Update ADR count from 41 to 43
- **CLAUDE.md**: Update ADR count from 32 to 43
- **docs/user-guide.md**: Add 14 new REST endpoints (models, recording, training) to API reference table, document that `/ws/sensing` is available on the HTTP port (no dedicated WS port needed), update ADR count from 33 to 43

## Test plan

- [ ] Verify CHANGELOG entries match what was merged in PR #125
- [ ] Verify ADR count matches `ls docs/adr/ADR-*.md | wc -l` (43)
- [ ] Verify user guide API table includes all 14 new endpoints

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)