### PR TITLE
fix: safe PyTorch model loading (weights_only=True)

### DIFF
--- a/references/wifi_densepose_pytorch.py
+++ b/references/wifi_densepose_pytorch.py
@@ -441,7 +441,7 @@ class WiFiDensePoseTrainer:
         }, path)
     
     def load_model(self, path):
-        checkpoint = torch.load(path)
+        checkpoint = torch.load(path, map_location=self.device, weights_only=True)
         self.model.load_state_dict(checkpoint['model_state_dict'])
         self.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
 


### PR DESCRIPTION
## Summary

- Replace unsafe `torch.load(path)` with `torch.load(path, map_location=self.device, weights_only=True)` in `references/wifi_densepose_pytorch.py`
- Prevents pickle deserialization RCE (`trailofbits.python.pickles-in-pytorch`)
- Adds `map_location` for correct CPU/GPU device mapping

This is the correct fix for the vulnerability identified in PR #106 (now closed). That PR introduced a custom `RestrictedUnpickler` which had several issues (missing `import pickle`, broken `torch.save` replacement, ignored `map_location`, incomplete allowlist). PyTorch's built-in `weights_only=True` (available since 1.13) is the recommended mitigation — it disables pickle entirely for model loading.

## Test plan

- [ ] Verify `load_model()` works with existing `.pth` checkpoints
- [ ] Verify malicious pickle payloads are rejected with `weights_only=True`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)