### PR TITLE
Fix Docker container failing to start with /bin/sh Illegal option error

### DIFF
--- a/docker/Dockerfile.rust
+++ b/docker/Dockerfile.rust
@@ -53,4 +53,4 @@ ENV CSI_SOURCE=auto
 ENTRYPOINT ["/bin/sh", "-c"]
 # Shell-form CMD allows $CSI_SOURCE to be substituted at container start.
 # The ENV default above (CSI_SOURCE=auto) applies when the variable is unset.
-CMD ["/app/sensing-server --source ${CSI_SOURCE} --tick-ms 100 --ui-path /app/ui --http-port 3000 --ws-port 3001"]
+CMD /app/sensing-server --source ${CSI_SOURCE} --tick-ms 100 --ui-path /app/ui --http-port 3000 --ws-port 3001


### PR DESCRIPTION
Fixes #153. The Dockerfile.rust used exec form for CMD (JSON array) with /bin/sh -c ENTRYPOINT, which caused /bin/sh to receive multiple arguments instead of the single command string expected by the -c flag. This resulted in the /bin/sh: 0: Illegal option -- error when running the container with additional arguments like --source esp32.

Changed CMD from exec form to shell form by removing the JSON array brackets, allowing the command to be passed correctly to /bin/sh -c and enabling proper environment variable expansion and argument handling.