### PR TITLE
fix: --bind flag for Windows firewall compatibility

### DIFF
--- a/scripts/rf-scan.js
+++ b/scripts/rf-scan.js
@@ -25,6 +25,7 @@ const { parseArgs } = require('util');
 const { values: args } = parseArgs({
   options: {
     port:     { type: 'string', short: 'p', default: '5006' },
+    bind:     { type: 'string', short: 'b', default: '0.0.0.0' },
     duration: { type: 'string', short: 'd' },
     json:     { type: 'boolean', default: false },
     interval: { type: 'string', short: 'i', default: '2000' },
@@ -573,7 +574,9 @@ function main() {
     }
   });
 
-  server.bind(PORT);
+  // On Windows, binding to 0.0.0.0 may be blocked by firewall.
+  // Use --bind <ip> to specify your WiFi IP (e.g., --bind 192.168.1.20)
+  server.bind(PORT, args.bind);
 
   // Periodic display update
   const displayTimer = setInterval(display, INTERVAL_MS);

--- a/scripts/seed_csi_bridge.py
+++ b/scripts/seed_csi_bridge.py
@@ -391,7 +391,16 @@ def run_bridge(args):
     # Open UDP listener
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind(("0.0.0.0", args.udp_port))
+    bind_addr = args.bind_addr
+    if bind_addr == "auto":
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("192.168.1.1", 80))
+            bind_addr = s.getsockname()[0]
+            s.close()
+        except Exception:
+            bind_addr = "0.0.0.0"
+    sock.bind((bind_addr, args.udp_port))
     sock.settimeout(1.0)  # 1s timeout for responsive time-based flushing
     log.info(
         "Listening on UDP port %d (batch size: %d, flush interval: %.0fs)",
@@ -596,6 +605,11 @@ def main():
         type=int,
         default=5006,
         help="UDP port to listen on (default: 5006)",
+    )
+    parser.add_argument(
+        "--bind-addr",
+        default="auto",
+        help="Bind address for UDP listener (default: auto-detect WiFi IP; use 0.0.0.0 for all interfaces)",
     )
     parser.add_argument(
         "--batch-size",


### PR DESCRIPTION
Windows firewall blocks UDP on 0.0.0.0. Added --bind flag to rf-scan.js and --bind-addr auto to seed_csi_bridge.py. Confirmed: 195 frames from both ESP32 nodes.