### PR TITLE
fix(websocket): handle broadcast Lagged error + ping keepalive

### DIFF
--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/main.rs
@@ -1883,6 +1883,10 @@ async fn handle_ws_client(mut socket: WebSocket, state: SharedState) {
 
     info!("WebSocket client connected (sensing)");
 
+    // Ping keepalive to prevent proxy idle timeouts (Caddy, nginx, etc.)
+    let mut ping_interval = tokio::time::interval(std::time::Duration::from_secs(30));
+    ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     loop {
         tokio::select! {
             msg = rx.recv() => {
@@ -1892,13 +1896,24 @@ async fn handle_ws_client(mut socket: WebSocket, state: SharedState) {
                             break;
                         }
                     }
-                    Err(_) => break,
+                    // Lagged: client fell behind — skip missed frames, don't disconnect.
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::debug!("WS client lagged by {n} frames, skipping");
+                        continue;
+                    }
+                    Err(_) => break, // channel closed
+                }
+            }
+            _ = ping_interval.tick() => {
+                if socket.send(Message::Ping(vec![].into())).await.is_err() {
+                    break;
                 }
             }
             msg = socket.recv() => {
                 match msg {
                     Some(Ok(Message::Close(_))) | None => break,
-                    _ => {} // ignore client messages
+                    Some(Ok(Message::Pong(_))) => {} // keepalive response
+                    _ => {} // ignore other client messages
                 }
             }
         }


### PR DESCRIPTION
When the broadcast channel's recv() returns Lagged (client fell behind), the server previously treated it as fatal and dropped the connection. The client immediately reconnected, creating a visible 2-4s freeze cycle on the dashboard.

**Fix:**
- Lagged error: skip missed frames with `continue` instead of `break`
- Add 30s ping/pong keepalive to prevent reverse proxy idle timeouts (Caddy, nginx default 60s idle → drops long-lived WS connections)

**Testing:** 11 ESP32-S3 nodes streaming at ~20fps per node, sustained 154 frames over 8s, zero disconnects.

Fixes dashboard freezing in multi-node deployments.