### PR TITLE
feat(adr-018): source MAC in CSI frame V2 (magic 0xC5110006)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!scripts/lib/
+!scripts/lib/raw-csi.js
 lib64/
 parts/
 sdist/

--- a/docs/adr/ADR-018-esp32-dev-implementation.md
+++ b/docs/adr/ADR-018-esp32-dev-implementation.md
@@ -35,13 +35,15 @@ This ADR answers *how* to build it — the concrete development sequence, the sp
 
 ### Binary Frame Format (implemented in `esp32_parser.rs`)
 
+#### V1 Format (magic `0xC5110001`, 20-byte header)
+
 ```
 Offset  Size  Field
 0       4     Magic: 0xC5110001 (LE)
 4       1     Node ID (0-255)
 5       1     Number of antennas
 6       2     Number of subcarriers (LE u16)
-8       4     Frequency Hz (LE u32, e.g. 2412 for 2.4 GHz ch1)
+8       4     Frequency MHz (LE u32, e.g. 2437 for ch6)
 12      4     Sequence number (LE u32)
 16      1     RSSI (i8, dBm)
 17      1     Noise floor (i8, dBm)
@@ -49,11 +51,43 @@ Offset  Size  Field
 20      N*2   I/Q pairs: (i8, i8) per subcarrier, repeated per antenna
 ```
 
-Total frame size: 20 + (n_antennas × n_subcarriers × 2) bytes.
+Total frame size: 20 + (n_antennas x n_subcarriers x 2) bytes.
 
-For 3 antennas, 56 subcarriers: 20 + 336 = 356 bytes per frame.
+#### V2 Format (magic `0xC5110003`, 26-byte header)
 
-The firmware must write frames in this exact format. The parser already validates magic, bounds-checks `n_subcarriers` (≤512), and resyncs the stream on magic search for `parse_stream()`.
+V2 extends V1 with a 6-byte source MAC address at offset 20, identifying which WiFi transmitter's frame triggered the CSI measurement. This enables per-device CSI tracking.
+
+```
+Offset  Size  Field
+0       4     Magic: 0xC5110003 (LE)
+4       1     Node ID (0-255)
+5       1     Number of antennas
+6       2     Number of subcarriers (LE u16)
+8       4     Frequency MHz (LE u32, e.g. 2437 for ch6)
+12      4     Sequence number (LE u32)
+16      1     RSSI (i8, dBm)
+17      1     Noise floor (i8, dBm)
+18      2     Reserved (zero)
+20      6     Source MAC address (network byte order)
+26      N*2   I/Q pairs: (i8, i8) per subcarrier, repeated per antenna
+```
+
+Total frame size: 26 + (n_antennas x n_subcarriers x 2) bytes.
+
+#### Backward Compatibility
+
+All parsers accept both V1 and V2 frames. V1 frames produce `source_mac = None`. During mixed-firmware rollout, nodes running old firmware send V1 and nodes running new firmware send V2 — both parse correctly.
+
+#### Magic Number Family
+
+| Magic | Format | Description |
+|-------|--------|-------------|
+| `0xC5110001` | CSI V1 | 20-byte header, no source MAC |
+| `0xC5110002` | Vitals | Edge-computed vital signs (ADR-039) |
+| `0xC5110003` | CSI V2 | 26-byte header, includes source MAC |
+| `0xC5110004` | WASM | WASM module events (ADR-040) |
+
+The firmware must write frames in the V2 format. The parser validates magic, bounds-checks `n_subcarriers` (<=256), and resyncs the stream on magic search for `parse_stream()`.
 
 ## Decision
 

--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -73,7 +73,7 @@ static esp_timer_handle_t s_hop_timer = NULL;
  * Serialize CSI data into ADR-018 V2 binary frame format.
  *
  * V2 layout (26-byte header):
- *   [0..3]   Magic: 0xC5110003 (LE) — V2
+ *   [0..3]   Magic: 0xC5110006 (LE) — V2
  *   [4]      Node ID
  *   [5]      Number of antennas (rx_ctrl.rx_ant + 1 if available, else 1)
  *   [6..7]   Number of subcarriers (LE u16) = len / (2 * n_antennas)

--- a/firmware/esp32-csi-node/main/csi_collector.c
+++ b/firmware/esp32-csi-node/main/csi_collector.c
@@ -70,10 +70,10 @@ static uint8_t  s_hop_index   = 0;
 static esp_timer_handle_t s_hop_timer = NULL;
 
 /**
- * Serialize CSI data into ADR-018 binary frame format.
+ * Serialize CSI data into ADR-018 V2 binary frame format.
  *
- * Layout:
- *   [0..3]   Magic: 0xC5110001 (LE)
+ * V2 layout (26-byte header):
+ *   [0..3]   Magic: 0xC5110003 (LE) — V2
  *   [4]      Node ID
  *   [5]      Number of antennas (rx_ctrl.rx_ant + 1 if available, else 1)
  *   [6..7]   Number of subcarriers (LE u16) = len / (2 * n_antennas)
@@ -82,7 +82,8 @@ static esp_timer_handle_t s_hop_timer = NULL;
  *   [16]     RSSI (i8)
  *   [17]     Noise floor (i8)
  *   [18..19] Reserved
- *   [20..]   I/Q data (raw bytes from ESP-IDF callback)
+ *   [20..25] Source MAC address (6 bytes, network byte order)
+ *   [26..]   I/Q data (raw bytes from ESP-IDF callback)
  */
 size_t csi_serialize_frame(const wifi_csi_info_t *info, uint8_t *buf, size_t buf_len)
 {
@@ -94,7 +95,7 @@ size_t csi_serialize_frame(const wifi_csi_info_t *info, uint8_t *buf, size_t buf
     uint16_t iq_len = (uint16_t)info->len;
     uint16_t n_subcarriers = iq_len / (2 * n_antennas);
 
-    size_t frame_size = CSI_HEADER_SIZE + iq_len;
+    size_t frame_size = CSI_HEADER_SIZE_V2 + iq_len;
     if (frame_size > buf_len) {
         ESP_LOGW(TAG, "Buffer too small: need %u, have %u", (unsigned)frame_size, (unsigned)buf_len);
         return 0;
@@ -113,8 +114,8 @@ size_t csi_serialize_frame(const wifi_csi_info_t *info, uint8_t *buf, size_t buf
         freq_mhz = 0;
     }
 
-    /* Magic (LE) */
-    uint32_t magic = CSI_MAGIC;
+    /* Magic (LE) — V2 includes source MAC */
+    uint32_t magic = CSI_MAGIC_V2;
     memcpy(&buf[0], &magic, 4);
 
     /* Node ID (from NVS runtime config, not compile-time Kconfig) */
@@ -143,8 +144,17 @@ size_t csi_serialize_frame(const wifi_csi_info_t *info, uint8_t *buf, size_t buf
     buf[18] = 0;
     buf[19] = 0;
 
+    /* Source MAC address (6 bytes, network byte order) — V2 extension */
+    memcpy(&buf[20], info->mac, 6);
+
+    ESP_LOGD(TAG, "V2 frame: node=%u mac=%02x:%02x:%02x:%02x:%02x:%02x seq=%u",
+             g_nvs_config.node_id,
+             info->mac[0], info->mac[1], info->mac[2],
+             info->mac[3], info->mac[4], info->mac[5],
+             seq);
+
     /* I/Q data */
-    memcpy(&buf[CSI_HEADER_SIZE], info->buf, iq_len);
+    memcpy(&buf[CSI_HEADER_SIZE_V2], info->buf, iq_len);
 
     return frame_size;
 }

--- a/firmware/esp32-csi-node/main/csi_collector.h
+++ b/firmware/esp32-csi-node/main/csi_collector.h
@@ -11,14 +11,20 @@
 #include "esp_err.h"
 #include "esp_wifi_types.h"
 
-/** ADR-018 magic number. */
+/** ADR-018 V1 magic number (no source MAC). */
 #define CSI_MAGIC 0xC5110001
 
-/** ADR-018 header size in bytes. */
+/** ADR-018 V2 magic number (includes 6-byte source MAC). */
+#define CSI_MAGIC_V2 0xC5110003
+
+/** ADR-018 V1 header size in bytes. */
 #define CSI_HEADER_SIZE 20
 
-/** Maximum frame buffer size (header + 4 antennas * 256 subcarriers * 2 bytes). */
-#define CSI_MAX_FRAME_SIZE (CSI_HEADER_SIZE + 4 * 256 * 2)
+/** ADR-018 V2 header size in bytes (V1 + 6-byte source MAC). */
+#define CSI_HEADER_SIZE_V2 26
+
+/** Maximum frame buffer size (V2 header + 4 antennas * 256 subcarriers * 2 bytes). */
+#define CSI_MAX_FRAME_SIZE (CSI_HEADER_SIZE_V2 + 4 * 256 * 2)
 
 /** Maximum number of channels in the hop table (ADR-029). */
 #define CSI_HOP_CHANNELS_MAX 6

--- a/firmware/esp32-csi-node/main/csi_collector.h
+++ b/firmware/esp32-csi-node/main/csi_collector.h
@@ -15,7 +15,7 @@
 #define CSI_MAGIC 0xC5110001
 
 /** ADR-018 V2 magic number (includes 6-byte source MAC). */
-#define CSI_MAGIC_V2 0xC5110003
+#define CSI_MAGIC_V2 0xC5110006
 
 /** ADR-018 V1 header size in bytes. */
 #define CSI_HEADER_SIZE 20

--- a/rust-port/wifi-densepose-rs/Cargo.lock
+++ b/rust-port/wifi-densepose-rs/Cargo.lock
@@ -141,6 +141,15 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -622,6 +631,27 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cauchy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff11ddd2af3b5e80dd0297fee6e56ac038d9bdc549573cdb51bd6d2efe7f05e"
+dependencies = [
+ "num-complex",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "cblas-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6feecd82cce51b0204cf063f0041d69f24ce83f680d87514b004248e7b0fa65"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cc"
@@ -1421,6 +1451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,7 +1949,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "num-traits",
  "rstar 0.10.0",
  "rstar 0.11.0",
@@ -2781,6 +2822,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "katexit"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfb0b7ce7938f84a5ecbdca5d0a991e46bc9d6d078934ad5e92c5270fe547db"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +2853,29 @@ dependencies = [
  "html5ever",
  "indexmap 2.13.0",
  "selectors",
+]
+
+[[package]]
+name = "lapack-sys"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447f56c85fb410a7a3d36701b2153c1018b1d2b908c5fbaf01c1b04fac33bcbe"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lax"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f96a229d9557112e574164f8024ce703625ad9f88a90964c1780809358e53da"
+dependencies = [
+ "cauchy",
+ "katexit",
+ "lapack-sys",
+ "num-traits",
+ "openblas-src",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2867,7 +2942,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3218,7 +3296,7 @@ version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -3271,6 +3349,9 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
+ "approx 0.4.0",
+ "cblas-sys",
+ "libc",
  "matrixmultiply",
  "num-complex",
  "num-integer",
@@ -3308,6 +3389,22 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "ndarray-linalg"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e8dda0c941b64a85c5deb2b3e0144aca87aced64678adfc23eacea6d2cc42"
+dependencies = [
+ "cauchy",
+ "katexit",
+ "lax",
+ "ndarray 0.15.6",
+ "num-complex",
+ "num-traits",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3441,6 +3538,8 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
  "num-traits",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -3671,6 +3770,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "openblas-build"
+version = "0.10.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd235aa8876fa5c4be452efde09b9b8bafa19aea0bf14a4926508213082439a3"
+dependencies = [
+ "anyhow",
+ "cc",
+ "flate2",
+ "tar",
+ "thiserror 2.0.18",
+ "ureq",
+]
+
+[[package]]
+name = "openblas-src"
+version = "0.10.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fccd2c4f5271ab871f2069cb6f1a13ef2c0db50e1145ce03428ee541f4c63c4f"
+dependencies = [
+ "dirs",
+ "openblas-build",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3819,7 +3944,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -4094,6 +4219,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -4690,6 +4821,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5737,7 +5877,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "num-complex",
  "num-traits",
  "paste",
@@ -5826,7 +5966,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -6096,6 +6236,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -7673,7 +7824,7 @@ dependencies = [
 name = "wifi-densepose-hardware"
 version = "0.3.0"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "byteorder",
  "chrono",
  "clap",
@@ -7694,7 +7845,7 @@ name = "wifi-densepose-mat"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "approx",
+ "approx 0.5.1",
  "async-trait",
  "axum",
  "chrono",
@@ -7747,7 +7898,7 @@ dependencies = [
 name = "wifi-densepose-ruvector"
 version = "0.3.0"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "criterion",
  "ruvector-attention 2.0.4",
  "ruvector-attn-mincut",
@@ -7769,7 +7920,6 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
- "ruvector-mincut",
  "serde",
  "serde_json",
  "tempfile",
@@ -7777,6 +7927,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "wifi-densepose-signal",
  "wifi-densepose-wifiscan",
 ]
 
@@ -7789,6 +7940,7 @@ dependencies = [
  "midstreamer-attractor",
  "midstreamer-temporal-compare",
  "ndarray 0.15.6",
+ "ndarray-linalg",
  "num-complex",
  "num-traits",
  "proptest",
@@ -7808,7 +7960,7 @@ name = "wifi-densepose-train"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "approx",
+ "approx 0.5.1",
  "chrono",
  "clap",
  "criterion",
@@ -8620,6 +8772,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/bridge.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/bridge.rs
@@ -105,6 +105,7 @@ mod tests {
                     rx_antennas: n_antennas,
                 },
                 sequence: 42,
+                source_mac: None,
             },
             subcarriers,
         }

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/csi_frame.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/csi_frame.rs
@@ -57,7 +57,7 @@ impl CsiFrame {
     }
 }
 
-/// Metadata associated with a CSI frame (ADR-018 format).
+/// Metadata associated with a CSI frame (ADR-018 V1/V2 format).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CsiMetadata {
     /// Timestamp when frame was received
@@ -80,6 +80,10 @@ pub struct CsiMetadata {
     pub antenna_config: AntennaConfig,
     /// Sequence number for ordering
     pub sequence: u32,
+    /// Source MAC address of the WiFi frame that triggered CSI (V2 only).
+    /// `None` for V1 frames (magic 0xC5110001).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_mac: Option<[u8; 6]>,
 }
 
 /// WiFi channel bandwidth.
@@ -154,6 +158,7 @@ mod tests {
                 bandwidth: Bandwidth::Bw20,
                 antenna_config: AntennaConfig::default(),
                 sequence: 1,
+                source_mac: None,
             },
             subcarriers: vec![
                 SubcarrierData { i: 100, q: 0, index: -28 },

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/error.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/error.rs
@@ -20,7 +20,7 @@ pub enum ParseError {
     },
 
     /// The frame header magic is not any recognized CSI version.
-    #[error("Unknown CSI magic: {got:#010x} (expected 0xC5110001 V1 or 0xC5110003 V2)")]
+    #[error("Unknown CSI magic: {got:#010x} (expected 0xC5110001 V1 or 0xC5110006 V2)")]
     UnknownMagic {
         got: u32,
     },

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/error.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/error.rs
@@ -13,9 +13,15 @@ pub enum ParseError {
     },
 
     /// The frame header magic bytes don't match expected values.
-    #[error("Invalid magic: expected {expected:#06x}, got {got:#06x}")]
+    #[error("Invalid magic: expected {expected:#010x}, got {got:#010x}")]
     InvalidMagic {
         expected: u32,
+        got: u32,
+    },
+
+    /// The frame header magic is not any recognized CSI version.
+    #[error("Unknown CSI magic: {got:#010x} (expected 0xC5110001 V1 or 0xC5110003 V2)")]
+    UnknownMagic {
         got: u32,
     },
 

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/esp32_parser.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/esp32_parser.rs
@@ -34,11 +34,17 @@ use std::io::Cursor;
 use crate::csi_frame::{AntennaConfig, Bandwidth, CsiFrame, CsiMetadata, SubcarrierData};
 use crate::error::ParseError;
 
-/// ESP32 CSI binary frame magic number (ADR-018).
+/// ESP32 CSI binary frame magic number — V1 (ADR-018, no source MAC).
 const ESP32_CSI_MAGIC: u32 = 0xC5110001;
 
-/// ADR-018 header size in bytes (before I/Q data).
+/// ESP32 CSI binary frame magic number — V2 (ADR-018, includes 6-byte source MAC).
+const ESP32_CSI_MAGIC_V2: u32 = 0xC5110003;
+
+/// ADR-018 V1 header size in bytes (before I/Q data).
 const HEADER_SIZE: usize = 20;
+
+/// ADR-018 V2 header size in bytes (V1 + 6-byte source MAC).
+const HEADER_SIZE_V2: usize = 26;
 
 /// Maximum valid subcarrier count for ESP32 (80 MHz bandwidth).
 const MAX_SUBCARRIERS: usize = 256;
@@ -70,12 +76,22 @@ impl Esp32CsiParser {
             got: 0,
         })?;
 
-        if magic != ESP32_CSI_MAGIC {
-            return Err(ParseError::InvalidMagic {
-                expected: ESP32_CSI_MAGIC,
-                got: magic,
-            });
-        }
+        // Determine frame version from magic
+        let (header_size, is_v2) = match magic {
+            ESP32_CSI_MAGIC => (HEADER_SIZE, false),
+            ESP32_CSI_MAGIC_V2 => {
+                if data.len() < HEADER_SIZE_V2 {
+                    return Err(ParseError::InsufficientData {
+                        needed: HEADER_SIZE_V2,
+                        got: data.len(),
+                    });
+                }
+                (HEADER_SIZE_V2, true)
+            }
+            _ => {
+                return Err(ParseError::UnknownMagic { got: magic });
+            }
+        };
 
         // Node ID (offset 4, 1 byte)
         let node_id = cursor.read_u8().map_err(|_| ParseError::ByteError {
@@ -136,10 +152,19 @@ impl Esp32CsiParser {
             message: "Failed to read reserved bytes".into(),
         })?;
 
+        // Source MAC (V2 only: offset 20, 6 bytes)
+        let source_mac = if is_v2 {
+            let mut mac = [0u8; 6];
+            mac.copy_from_slice(&data[20..26]);
+            Some(mac)
+        } else {
+            None
+        };
+
         // I/Q data: n_antennas * n_subcarriers * 2 bytes
         let iq_pair_count = n_antennas as usize * n_subcarriers;
         let iq_byte_count = iq_pair_count * 2;
-        let total_frame_size = HEADER_SIZE + iq_byte_count;
+        let total_frame_size = header_size + iq_byte_count;
 
         if data.len() < total_frame_size {
             return Err(ParseError::InsufficientData {
@@ -149,7 +174,7 @@ impl Esp32CsiParser {
         }
 
         // Parse I/Q pairs — stored as [ant0_sc0_I, ant0_sc0_Q, ant0_sc1_I, ant0_sc1_Q, ..., ant1_sc0_I, ...]
-        let iq_start = HEADER_SIZE;
+        let iq_start = header_size;
         let mut subcarriers = Vec::with_capacity(iq_pair_count);
 
         let half = n_subcarriers as i16 / 2;
@@ -197,6 +222,7 @@ impl Esp32CsiParser {
                     rx_antennas: n_antennas,
                 },
                 sequence,
+                source_mac,
             },
             subcarriers,
         };
@@ -227,7 +253,7 @@ impl Esp32CsiParser {
                             data[offset + 2],
                             data[offset + 3],
                         ]);
-                        if candidate == ESP32_CSI_MAGIC {
+                        if candidate == ESP32_CSI_MAGIC || candidate == ESP32_CSI_MAGIC_V2 {
                             break;
                         }
                         offset += 1;
@@ -281,6 +307,50 @@ mod tests {
         buf
     }
 
+    /// Build a valid ADR-018 V2 ESP32 CSI frame with source MAC.
+    fn build_test_frame_v2(
+        node_id: u8,
+        n_antennas: u8,
+        subcarrier_pairs: &[(i8, i8)],
+        source_mac: [u8; 6],
+    ) -> Vec<u8> {
+        let n_subcarriers = if n_antennas == 0 {
+            subcarrier_pairs.len()
+        } else {
+            subcarrier_pairs.len() / n_antennas as usize
+        };
+
+        let mut buf = Vec::new();
+
+        // Magic V2 (offset 0)
+        buf.extend_from_slice(&ESP32_CSI_MAGIC_V2.to_le_bytes());
+        // Node ID (offset 4)
+        buf.push(node_id);
+        // Number of antennas (offset 5)
+        buf.push(n_antennas);
+        // Number of subcarriers (offset 6, LE u16)
+        buf.extend_from_slice(&(n_subcarriers as u16).to_le_bytes());
+        // Frequency MHz (offset 8, LE u32)
+        buf.extend_from_slice(&2437u32.to_le_bytes());
+        // Sequence number (offset 12, LE u32)
+        buf.extend_from_slice(&42u32.to_le_bytes());
+        // RSSI (offset 16, i8)
+        buf.push((-50i8) as u8);
+        // Noise floor (offset 17, i8)
+        buf.push((-95i8) as u8);
+        // Reserved (offset 18, 2 bytes)
+        buf.extend_from_slice(&[0u8; 2]);
+        // Source MAC (offset 20, 6 bytes)
+        buf.extend_from_slice(&source_mac);
+        // I/Q data (offset 26)
+        for (i, q) in subcarrier_pairs {
+            buf.push(*i as u8);
+            buf.push(*q as u8);
+        }
+
+        buf
+    }
+
     #[test]
     fn test_parse_valid_frame() {
         // 1 antenna, 56 subcarriers
@@ -313,7 +383,7 @@ mod tests {
         // Corrupt magic
         data[0] = 0xFF;
         let result = Esp32CsiParser::parse_frame(&data);
-        assert!(matches!(result, Err(ParseError::InvalidMagic { .. })));
+        assert!(matches!(result, Err(ParseError::UnknownMagic { .. })));
     }
 
     #[test]
@@ -381,5 +451,65 @@ mod tests {
         assert_eq!(frame.metadata.n_subcarriers, 4);
         assert_eq!(frame.subcarrier_count(), 12); // 3 antennas * 4 subcarriers
         assert_eq!(frame.metadata.antenna_config.rx_antennas, 3);
+    }
+
+    #[test]
+    fn test_parse_v2_frame() {
+        let mac = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+        let pairs: Vec<(i8, i8)> = (0..56).map(|i| (i as i8, (i * 2 % 127) as i8)).collect();
+        let data = build_test_frame_v2(3, 1, &pairs, mac);
+
+        let (frame, consumed) = Esp32CsiParser::parse_frame(&data).unwrap();
+
+        assert_eq!(consumed, HEADER_SIZE_V2 + 56 * 2);
+        assert_eq!(frame.metadata.node_id, 3);
+        assert_eq!(frame.metadata.source_mac, Some(mac));
+        assert_eq!(frame.metadata.sequence, 42);
+        assert_eq!(frame.metadata.rssi_dbm, -50);
+        assert_eq!(frame.metadata.n_subcarriers, 56);
+        assert!(frame.is_valid());
+    }
+
+    #[test]
+    fn test_parse_v1_still_works() {
+        // Existing V1 frames must parse with source_mac = None
+        let pairs: Vec<(i8, i8)> = (0..4).map(|i| (10 + i, 20 + i)).collect();
+        let data = build_test_frame(1, 1, &pairs);
+
+        let (frame, consumed) = Esp32CsiParser::parse_frame(&data).unwrap();
+
+        assert_eq!(consumed, HEADER_SIZE + 4 * 2);
+        assert_eq!(frame.metadata.source_mac, None);
+        assert_eq!(frame.metadata.node_id, 1);
+    }
+
+    #[test]
+    fn test_parse_stream_mixed_v1_v2() {
+        let pairs: Vec<(i8, i8)> = (0..4).map(|i| (10 + i, 20 + i)).collect();
+        let mac = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let v1_frame = build_test_frame(1, 1, &pairs);
+        let v2_frame = build_test_frame_v2(2, 1, &pairs, mac);
+
+        let mut combined = Vec::new();
+        combined.extend_from_slice(&v1_frame);
+        combined.extend_from_slice(&v2_frame);
+
+        let (frames, _) = Esp32CsiParser::parse_stream(&combined);
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].metadata.node_id, 1);
+        assert_eq!(frames[0].metadata.source_mac, None);
+        assert_eq!(frames[1].metadata.node_id, 2);
+        assert_eq!(frames[1].metadata.source_mac, Some(mac));
+    }
+
+    #[test]
+    fn test_v2_insufficient_header() {
+        // V2 magic but only 22 bytes (need 26)
+        let mut data = vec![0u8; 22];
+        data[0..4].copy_from_slice(&ESP32_CSI_MAGIC_V2.to_le_bytes());
+        data[5] = 1; // n_antennas
+
+        let result = Esp32CsiParser::parse_frame(&data);
+        assert!(matches!(result, Err(ParseError::InsufficientData { needed: 26, .. })));
     }
 }

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/esp32_parser.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-hardware/src/esp32_parser.rs
@@ -38,7 +38,7 @@ use crate::error::ParseError;
 const ESP32_CSI_MAGIC: u32 = 0xC5110001;
 
 /// ESP32 CSI binary frame magic number — V2 (ADR-018, includes 6-byte source MAC).
-const ESP32_CSI_MAGIC_V2: u32 = 0xC5110003;
+const ESP32_CSI_MAGIC_V2: u32 = 0xC5110006;
 
 /// ADR-018 V1 header size in bytes (before I/Q data).
 const HEADER_SIZE: usize = 20;

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -65,18 +65,30 @@ pub fn parse_wasm_output(buf: &[u8]) -> Option<WasmOutputPacket> {
 pub fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
     if buf.len() < 20 { return None; }
     let magic = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
-    if magic != 0xC511_0001 { return None; }
 
+    // Determine frame version and header size
+    let (header_size, source_mac) = match magic {
+        0xC511_0001 => (20usize, None),
+        0xC511_0003 => {
+            if buf.len() < 26 { return None; }
+            let mut mac = [0u8; 6];
+            mac.copy_from_slice(&buf[20..26]);
+            (26usize, Some(mac))
+        }
+        _ => return None,
+    };
+
+    // ADR-018 header fields at correct offsets
     let node_id = buf[4];
     let n_antennas = buf[5];
-    let n_subcarriers = buf[6];
-    let freq_mhz = u16::from_le_bytes([buf[8], buf[9]]);
-    let sequence = u32::from_le_bytes([buf[10], buf[11], buf[12], buf[13]]);
-    let rssi_raw = buf[14] as i8;
+    let n_subcarriers = u16::from_le_bytes([buf[6], buf[7]]);
+    let freq_mhz = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+    let sequence = u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]);
+    let rssi_raw = buf[16] as i8;
     let rssi = if rssi_raw > 0 { rssi_raw.saturating_neg() } else { rssi_raw };
-    let noise_floor = buf[15] as i8;
+    let noise_floor = buf[17] as i8;
 
-    let iq_start = 20;
+    let iq_start = header_size;
     let n_pairs = n_antennas as usize * n_subcarriers as usize;
     let expected_len = iq_start + n_pairs * 2;
     if buf.len() < expected_len { return None; }
@@ -92,8 +104,93 @@ pub fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
 
     Some(Esp32Frame {
         magic, node_id, n_antennas, n_subcarriers, freq_mhz, sequence,
-        rssi, noise_floor, amplitudes, phases,
+        rssi, noise_floor, amplitudes, phases, source_mac,
     })
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    /// Build a V1 ADR-018 frame with correct offsets.
+    fn build_v1_frame(node_id: u8, n_sub: u16, seq: u32, rssi: i8, noise: i8) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0xC511_0001u32.to_le_bytes()); // magic
+        buf.push(node_id);                                     // node_id
+        buf.push(1);                                           // n_antennas
+        buf.extend_from_slice(&n_sub.to_le_bytes());           // n_subcarriers (u16 LE)
+        buf.extend_from_slice(&2437u32.to_le_bytes());         // freq_mhz (u32 LE)
+        buf.extend_from_slice(&seq.to_le_bytes());             // sequence (u32 LE)
+        buf.push(rssi as u8);                                  // rssi (i8)
+        buf.push(noise as u8);                                 // noise_floor (i8)
+        buf.extend_from_slice(&[0u8; 2]);                      // reserved
+        // I/Q: n_sub pairs of (1, 2)
+        for _ in 0..n_sub {
+            buf.push(1u8); // I
+            buf.push(2u8); // Q
+        }
+        buf
+    }
+
+    /// Build a V2 ADR-018 frame with source MAC.
+    fn build_v2_frame(node_id: u8, n_sub: u16, source_mac: [u8; 6]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0xC511_0003u32.to_le_bytes()); // magic V2
+        buf.push(node_id);
+        buf.push(1);                                           // n_antennas
+        buf.extend_from_slice(&n_sub.to_le_bytes());
+        buf.extend_from_slice(&2437u32.to_le_bytes());
+        buf.extend_from_slice(&99u32.to_le_bytes());           // sequence
+        buf.push((-45i8) as u8);                               // rssi
+        buf.push((-90i8) as u8);                               // noise_floor
+        buf.extend_from_slice(&[0u8; 2]);                      // reserved
+        buf.extend_from_slice(&source_mac);                    // source MAC (6 bytes)
+        for _ in 0..n_sub {
+            buf.push(3u8);
+            buf.push(4u8);
+        }
+        buf
+    }
+
+    #[test]
+    fn test_v1_correct_offsets() {
+        let frame = parse_esp32_frame(&build_v1_frame(5, 56, 12345, -42, -88)).unwrap();
+        assert_eq!(frame.node_id, 5);
+        assert_eq!(frame.n_subcarriers, 56);
+        assert_eq!(frame.sequence, 12345);
+        assert_eq!(frame.rssi, -42);
+        assert_eq!(frame.noise_floor, -88);
+        assert_eq!(frame.freq_mhz, 2437);
+        assert_eq!(frame.source_mac, None);
+        assert_eq!(frame.amplitudes.len(), 56);
+    }
+
+    #[test]
+    fn test_v2_with_source_mac() {
+        let mac = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+        let frame = parse_esp32_frame(&build_v2_frame(3, 56, mac)).unwrap();
+        assert_eq!(frame.node_id, 3);
+        assert_eq!(frame.source_mac, Some(mac));
+        assert_eq!(frame.sequence, 99);
+        assert_eq!(frame.rssi, -45);
+        assert_eq!(frame.noise_floor, -90);
+        assert_eq!(frame.amplitudes.len(), 56);
+    }
+
+    #[test]
+    fn test_v2_short_buffer_rejected() {
+        // V2 magic but only 22 bytes
+        let mut buf = vec![0u8; 22];
+        buf[0..4].copy_from_slice(&0xC511_0003u32.to_le_bytes());
+        assert!(parse_esp32_frame(&buf).is_none());
+    }
+
+    #[test]
+    fn test_unknown_magic_rejected() {
+        let mut buf = build_v1_frame(1, 4, 1, -50, -90);
+        buf[0..4].copy_from_slice(&0xDEADBEEFu32.to_le_bytes());
+        assert!(parse_esp32_frame(&buf).is_none());
+    }
 }
 
 // ── Signal field generation ─────────────────────────────────────────────────
@@ -659,10 +756,10 @@ pub fn generate_simulated_frame(tick: u64) -> Esp32Frame {
         phases.push((i as f64 * 0.2 + t * 0.5).sin() * std::f64::consts::PI);
     }
     Esp32Frame {
-        magic: 0xC511_0001, node_id: 1, n_antennas: 1, n_subcarriers: n_sub as u8,
+        magic: 0xC511_0001, node_id: 1, n_antennas: 1, n_subcarriers: n_sub as u16,
         freq_mhz: 2437, sequence: tick as u32,
         rssi: (-40.0 + 5.0 * (t * 0.2).sin()) as i8, noise_floor: -90,
-        amplitudes, phases,
+        amplitudes, phases, source_mac: None,
     }
 }
 

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/csi.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/csi.rs
@@ -10,6 +10,11 @@ use crate::vital_signs::VitalSigns;
 
 // ── ESP32 UDP frame parsers ─────────────────────────────────────────────────
 
+const ESP32_CSI_MAGIC_V1: u32 = 0xC511_0001;
+const ESP32_CSI_MAGIC_V2: u32 = 0xC511_0006;
+const ESP32_MAX_ANTENNAS: u8 = 4;
+const ESP32_MAX_SUBCARRIERS: u16 = 256;
+
 /// Parse a 32-byte edge vitals packet (magic 0xC511_0002).
 pub fn parse_esp32_vitals(buf: &[u8]) -> Option<Esp32VitalsPacket> {
     if buf.len() < 32 { return None; }
@@ -68,8 +73,8 @@ pub fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
 
     // Determine frame version and header size
     let (header_size, source_mac) = match magic {
-        0xC511_0001 => (20usize, None),
-        0xC511_0003 => {
+        ESP32_CSI_MAGIC_V1 => (20usize, None),
+        ESP32_CSI_MAGIC_V2 => {
             if buf.len() < 26 { return None; }
             let mut mac = [0u8; 6];
             mac.copy_from_slice(&buf[20..26]);
@@ -82,6 +87,12 @@ pub fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
     let node_id = buf[4];
     let n_antennas = buf[5];
     let n_subcarriers = u16::from_le_bytes([buf[6], buf[7]]);
+    if n_antennas == 0 || n_antennas > ESP32_MAX_ANTENNAS {
+        return None;
+    }
+    if n_subcarriers == 0 || n_subcarriers > ESP32_MAX_SUBCARRIERS {
+        return None;
+    }
     let freq_mhz = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
     let sequence = u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]);
     let rssi_raw = buf[16] as i8;
@@ -115,7 +126,7 @@ mod parse_tests {
     /// Build a V1 ADR-018 frame with correct offsets.
     fn build_v1_frame(node_id: u8, n_sub: u16, seq: u32, rssi: i8, noise: i8) -> Vec<u8> {
         let mut buf = Vec::new();
-        buf.extend_from_slice(&0xC511_0001u32.to_le_bytes()); // magic
+        buf.extend_from_slice(&ESP32_CSI_MAGIC_V1.to_le_bytes()); // magic
         buf.push(node_id);                                     // node_id
         buf.push(1);                                           // n_antennas
         buf.extend_from_slice(&n_sub.to_le_bytes());           // n_subcarriers (u16 LE)
@@ -135,7 +146,7 @@ mod parse_tests {
     /// Build a V2 ADR-018 frame with source MAC.
     fn build_v2_frame(node_id: u8, n_sub: u16, source_mac: [u8; 6]) -> Vec<u8> {
         let mut buf = Vec::new();
-        buf.extend_from_slice(&0xC511_0003u32.to_le_bytes()); // magic V2
+        buf.extend_from_slice(&ESP32_CSI_MAGIC_V2.to_le_bytes()); // magic V2
         buf.push(node_id);
         buf.push(1);                                           // n_antennas
         buf.extend_from_slice(&n_sub.to_le_bytes());
@@ -181,7 +192,7 @@ mod parse_tests {
     fn test_v2_short_buffer_rejected() {
         // V2 magic but only 22 bytes
         let mut buf = vec![0u8; 22];
-        buf[0..4].copy_from_slice(&0xC511_0003u32.to_le_bytes());
+        buf[0..4].copy_from_slice(&ESP32_CSI_MAGIC_V2.to_le_bytes());
         assert!(parse_esp32_frame(&buf).is_none());
     }
 

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/main.rs
@@ -53,6 +53,8 @@ use tracing::{info, warn, debug, error};
 use rvf_container::{RvfBuilder, RvfContainerInfo, RvfReader, VitalSignConfig};
 use rvf_pipeline::ProgressiveLoader;
 use vital_signs::{VitalSignDetector, VitalSigns};
+use csi::parse_esp32_frame;
+use types::Esp32Frame;
 
 // ADR-022 Phase 3: Multi-BSSID pipeline integration
 use wifi_densepose_wifiscan::{
@@ -168,22 +170,7 @@ struct Args {
 }
 
 // ── Data types ───────────────────────────────────────────────────────────────
-
-/// ADR-018 ESP32 CSI binary frame header (20 bytes)
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-struct Esp32Frame {
-    magic: u32,
-    node_id: u8,
-    n_antennas: u8,
-    n_subcarriers: u8,
-    freq_mhz: u16,
-    sequence: u32,
-    rssi: i8,
-    noise_floor: i8,
-    amplitudes: Vec<f64>,
-    phases: Vec<f64>,
-}
+// Esp32Frame is defined in types.rs (ADR-018 V1/V2)
 
 /// Sensing update broadcast to WebSocket clients
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -683,70 +670,7 @@ fn parse_wasm_output(buf: &[u8]) -> Option<WasmOutputPacket> {
     })
 }
 
-// ── ESP32 UDP frame parser ───────────────────────────────────────────────────
-
-fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
-    if buf.len() < 20 {
-        return None;
-    }
-
-    let magic = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
-    if magic != 0xC511_0001 {
-        return None;
-    }
-
-    // Frame layout (must match firmware csi_collector.c):
-    //   [0..3]   magic (u32 LE)
-    //   [4]      node_id (u8)
-    //   [5]      n_antennas (u8)
-    //   [6..7]   n_subcarriers (u16 LE)
-    //   [8..11]  freq_mhz (u32 LE)
-    //   [12..15] sequence (u32 LE)
-    //   [16]     rssi (i8)
-    //   [17]     noise_floor (i8)
-    //   [18..19] reserved
-    //   [20..]   I/Q data
-    let node_id = buf[4];
-    let n_antennas = buf[5];
-    let n_subcarriers = buf[6];
-    let freq_mhz = u16::from_le_bytes([buf[8], buf[9]]);
-    let sequence = u32::from_le_bytes([buf[10], buf[11], buf[12], buf[13]]);
-    let rssi_raw = buf[14] as i8;
-    // Fix RSSI sign: ensure it's always negative (dBm convention).
-    let rssi = if rssi_raw > 0 { rssi_raw.saturating_neg() } else { rssi_raw };
-    let noise_floor = buf[15] as i8;
-
-    let iq_start = 20;
-    let n_pairs = n_antennas as usize * n_subcarriers as usize;
-    let expected_len = iq_start + n_pairs * 2;
-
-    if buf.len() < expected_len {
-        return None;
-    }
-
-    let mut amplitudes = Vec::with_capacity(n_pairs);
-    let mut phases = Vec::with_capacity(n_pairs);
-
-    for k in 0..n_pairs {
-        let i_val = buf[iq_start + k * 2] as i8 as f64;
-        let q_val = buf[iq_start + k * 2 + 1] as i8 as f64;
-        amplitudes.push((i_val * i_val + q_val * q_val).sqrt());
-        phases.push(q_val.atan2(i_val));
-    }
-
-    Some(Esp32Frame {
-        magic,
-        node_id,
-        n_antennas,
-        n_subcarriers,
-        freq_mhz,
-        sequence,
-        rssi,
-        noise_floor,
-        amplitudes,
-        phases,
-    })
-}
+// ESP32 UDP frame parser: uses csi::parse_esp32_frame (V1+V2 support, correct ADR-018 offsets)
 
 // ── Signal field generation ──────────────────────────────────────────────────
 
@@ -1545,13 +1469,14 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
             magic: 0xC511_0001,
             node_id: 0,
             n_antennas: 1,
-            n_subcarriers: obs_count.min(255) as u8,
+            n_subcarriers: obs_count as u16,
             freq_mhz: 2437,
             sequence: seq,
             rssi: first_rssi.clamp(-128.0, 127.0) as i8,
             noise_floor: -90,
             amplitudes: multi_ap_frame.amplitudes.clone(),
             phases: multi_ap_frame.phases.clone(),
+            source_mac: None,
         };
 
         // ── Step 4b: Update frame history and extract features ───────
@@ -1712,6 +1637,7 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
         noise_floor: -90,
         amplitudes: vec![signal_pct],
         phases: vec![0.0],
+        source_mac: None,
     };
 
     let mut s = state.write().await;
@@ -1856,13 +1782,14 @@ fn generate_simulated_frame(tick: u64) -> Esp32Frame {
         magic: 0xC511_0001,
         node_id: 1,
         n_antennas: 1,
-        n_subcarriers: n_sub as u8,
+        n_subcarriers: n_sub as u16,
         freq_mhz: 2437,
         sequence: tick as u32,
         rssi: (-40.0 + 5.0 * (t * 0.2).sin()) as i8,
         noise_floor: -90,
         amplitudes,
         phases,
+        source_mac: None,
     }
 }
 

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/recording.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/recording.rs
@@ -57,6 +57,12 @@ pub struct RecordingSession {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecordedFrame {
     pub timestamp: f64,
+    /// Node ID of the ESP32 that captured this frame.
+    #[serde(default)]
+    pub node_id: u8,
+    /// Source MAC of the WiFi frame that triggered CSI (V2 frames only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_mac: Option<String>,
     pub subcarriers: Vec<f64>,
     pub rssi: f64,
     pub noise_floor: f64,
@@ -114,6 +120,8 @@ pub type AppState = Arc<RwLock<super::AppStateInner>>;
 /// If recording is not active, it returns immediately.
 pub async fn maybe_record_frame(
     state: &AppState,
+    node_id: u8,
+    source_mac: Option<[u8; 6]>,
     subcarriers: &[f64],
     rssi: f64,
     noise_floor: f64,
@@ -145,6 +153,11 @@ pub async fn maybe_record_frame(
 
     let frame = RecordedFrame {
         timestamp: chrono::Utc::now().timestamp_millis() as f64 / 1000.0,
+        node_id,
+        source_mac: source_mac.map(|m| {
+            format!("{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                    m[0], m[1], m[2], m[3], m[4], m[5])
+        }),
         subcarriers: subcarriers.to_vec(),
         rssi,
         noise_floor,

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/types.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/types.rs
@@ -57,20 +57,22 @@ pub const BR_DEAD_BAND: f64 = 0.5;
 
 // ── ESP32 Frame ─────────────────────────────────────────────────────────────
 
-/// ADR-018 ESP32 CSI binary frame header (20 bytes)
+/// ADR-018 ESP32 CSI binary frame (V1: 20-byte header, V2: 26-byte header with source MAC)
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Esp32Frame {
     pub magic: u32,
     pub node_id: u8,
     pub n_antennas: u8,
-    pub n_subcarriers: u8,
-    pub freq_mhz: u16,
+    pub n_subcarriers: u16,
+    pub freq_mhz: u32,
     pub sequence: u32,
     pub rssi: i8,
     pub noise_floor: i8,
     pub amplitudes: Vec<f64>,
     pub phases: Vec<f64>,
+    /// Source MAC of the WiFi frame that triggered CSI (V2 only, None for V1).
+    pub source_mac: Option<[u8; 6]>,
 }
 
 // ── Sensing Update ──────────────────────────────────────────────────────────

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/tests/multi_node_test.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/tests/multi_node_test.rs
@@ -11,20 +11,19 @@
 use std::net::UdpSocket;
 use std::time::Duration;
 
-/// Build a minimal valid ESP32 CSI frame (magic 0xC511_0001).
+/// Build a minimal valid ESP32 CSI V1 frame (magic 0xC511_0001).
 ///
-/// Format (ADR-018):
-///   [0..3]  magic: 0xC511_0001 (LE)
-///   [4]     node_id
-///   [5]     n_antennas (1)
-///   [6]     n_subcarriers (e.g., 32)
-///   [7]     reserved
-///   [8..9]  freq_mhz (2437 = channel 6)
-///   [10..13] sequence (LE u32)
-///   [14]    rssi (signed)
-///   [15]    noise_floor
-///   [16..19] reserved
-///   [20..]  I/Q pairs (n_antennas * n_subcarriers * 2 bytes)
+/// Format (ADR-018 V1, 20-byte header):
+///   [0..3]   magic: 0xC511_0001 (LE)
+///   [4]      node_id
+///   [5]      n_antennas (1)
+///   [6..7]   n_subcarriers (LE u16)
+///   [8..11]  freq_mhz (LE u32, 2437 = channel 6)
+///   [12..15] sequence (LE u32)
+///   [16]     rssi (i8)
+///   [17]     noise_floor (i8)
+///   [18..19] reserved
+///   [20..]   I/Q pairs (n_antennas * n_subcarriers * 2 bytes)
 fn build_csi_frame(node_id: u8, seq: u32, rssi: i8, n_sub: u8) -> Vec<u8> {
     let n_pairs = n_sub as usize;
     let mut buf = vec![0u8; 20 + n_pairs * 2];
@@ -35,22 +34,24 @@ fn build_csi_frame(node_id: u8, seq: u32, rssi: i8, n_sub: u8) -> Vec<u8> {
 
     buf[4] = node_id;
     buf[5] = 1; // n_antennas
-    buf[6] = n_sub;
-    buf[7] = 0;
 
-    // freq = 2437 MHz (channel 6)
-    let freq: u16 = 2437;
-    buf[8..10].copy_from_slice(&freq.to_le_bytes());
+    // n_subcarriers (u16 LE at offset 6)
+    buf[6..8].copy_from_slice(&(n_sub as u16).to_le_bytes());
 
-    // sequence
-    buf[10..14].copy_from_slice(&seq.to_le_bytes());
+    // freq = 2437 MHz (u32 LE at offset 8)
+    buf[8..12].copy_from_slice(&2437u32.to_le_bytes());
 
-    buf[14] = rssi as u8;
-    buf[15] = (-90i8) as u8; // noise floor
+    // sequence (u32 LE at offset 12)
+    buf[12..16].copy_from_slice(&seq.to_le_bytes());
+
+    // rssi (i8 at offset 16)
+    buf[16] = rssi as u8;
+    // noise floor (i8 at offset 17)
+    buf[17] = (-90i8) as u8;
+
+    // reserved (offset 18-19, already zero)
 
     // Generate I/Q pairs with node-specific patterns.
-    // Different nodes produce different amplitude patterns so the server
-    // computes different features for each.
     for i in 0..n_pairs {
         let phase = (i as f64 + node_id as f64 * 0.5) * 0.3;
         let amplitude = 20.0 + (node_id as f64) * 5.0 + (phase.sin() * 10.0);

--- a/scripts/benchmark-rf-scan.js
+++ b/scripts/benchmark-rf-scan.js
@@ -23,6 +23,7 @@
 
 const dgram = require('dgram');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -43,8 +44,6 @@ const JSON_OUTPUT = args.json;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC   = 0xC5110001;
-const HEADER_SIZE = 20;
 const NULL_THRESHOLD = 2.0;
 
 // ---------------------------------------------------------------------------
@@ -100,42 +99,10 @@ const startTime = Date.now();
 // Packet parsing
 // ---------------------------------------------------------------------------
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  if (buf.readUInt32LE(0) !== CSI_MAGIC) return null;
-
-  const nodeId       = buf.readUInt8(4);
-  const nAntennas    = buf.readUInt8(5) || 1;
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz      = buf.readUInt32LE(8);
-  const rssi         = buf.readInt8(16);
-
-  const iqLen = nSubcarriers * nAntennas * 2;
-  if (buf.length < HEADER_SIZE + iqLen) return null;
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  const phases = new Float64Array(nSubcarriers);
-
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-    phases[sc] = Math.atan2(Q, I);
-  }
-
-  let channel = 0;
-  if (freqMhz >= 2412 && freqMhz <= 2484) {
-    channel = freqMhz === 2484 ? 14 : Math.round((freqMhz - 2412) / 5) + 1;
-  } else if (freqMhz >= 5180) {
-    channel = Math.round((freqMhz - 5000) / 5);
-  }
-
-  return { nodeId, nSubcarriers, freqMhz, rssi, amplitudes, phases, channel };
+  return parseRawCsiFrame(buf);
 }
 
 function handlePacket(buf, rinfo) {
-  if (buf.length < 4 || buf.readUInt32LE(0) !== CSI_MAGIC) return;
-
   const frame = parseCSIFrame(buf);
   if (!frame) return;
 

--- a/scripts/collect-training-data.py
+++ b/scripts/collect-training-data.py
@@ -7,7 +7,7 @@ files compatible with the Rust training pipeline (MmFiDataset / CsiDataset).
 
 Supports two packet formats:
   - ADR-069 feature vectors (magic 0xC5110003, 48 bytes) — 8-dim pre-extracted
-  - ADR-018 raw CSI frames (magic 0xC5110001, variable) — full subcarrier data
+  - ADR-018 raw CSI frames (V1/V2, variable) — full subcarrier data
 
 Usage:
     # Interactive — prompts for scenario labels
@@ -55,15 +55,17 @@ log = logging.getLogger("collect-data")
 # ── Packet formats (must match firmware) ─────────────────────────────────────
 
 # ADR-018 raw CSI frame header
-MAGIC_CSI_RAW = 0xC5110001
+MAGIC_CSI_RAW_V1 = 0xC5110001
+MAGIC_CSI_RAW_V2 = 0xC5110006
 # ADR-069 feature vector packet
 MAGIC_FEATURES = 0xC5110003
 FEATURE_PKT_FMT = "<IBBHq8f"
 FEATURE_PKT_SIZE = struct.calcsize(FEATURE_PKT_FMT)  # 48 bytes
 
-# Raw CSI header: magic(4) + node_id(1) + antenna_cfg(1) + n_sub(2) + rssi(1) + noise(1) + channel(1) + reserved(1) + timestamp_ms(4)
-RAW_CSI_HDR_FMT = "<IBBHbbBxI"
-RAW_CSI_HDR_SIZE = struct.calcsize(RAW_CSI_HDR_FMT)  # 16 bytes
+RAW_CSI_HEADER_SIZE_V1 = 20
+RAW_CSI_HEADER_SIZE_V2 = 26
+RAW_CSI_MAX_ANTENNAS = 4
+RAW_CSI_MAX_SUBCARRIERS = 256
 
 
 # ── Packet parsing ───────────────────────────────────────────────────────────
@@ -73,14 +75,14 @@ def parse_packet(data: bytes) -> Optional[dict]:
     if len(data) < 4:
         return None
 
-    magic = struct.unpack_from("<I", data)[0]
+    raw_packet = _parse_raw_csi_packet(data)
+    if raw_packet is not None:
+        return raw_packet
 
+    magic = struct.unpack_from("<I", data)[0]
     if magic == MAGIC_FEATURES and len(data) >= FEATURE_PKT_SIZE:
         return _parse_feature_packet(data)
-    elif magic == MAGIC_CSI_RAW and len(data) >= RAW_CSI_HDR_SIZE:
-        return _parse_raw_csi_packet(data)
-    else:
-        return None
+    return None
 
 
 def _parse_feature_packet(data: bytes) -> Optional[dict]:
@@ -112,42 +114,73 @@ def _parse_feature_packet(data: bytes) -> Optional[dict]:
 
 
 def _parse_raw_csi_packet(data: bytes) -> Optional[dict]:
-    """Parse ADR-018 raw CSI frame with full subcarrier data."""
-    try:
-        magic, node_id, ant_cfg, n_sub, rssi, noise, channel, ts_ms = struct.unpack_from(
-            RAW_CSI_HDR_FMT, data
-        )
-    except struct.error:
+    """Parse ADR-018 raw CSI frames (V1/V2) with full subcarrier data."""
+    if len(data) < RAW_CSI_HEADER_SIZE_V1:
         return None
 
-    if magic != MAGIC_CSI_RAW:
+    magic = struct.unpack_from("<I", data)[0]
+    if magic == MAGIC_CSI_RAW_V1:
+        header_size = RAW_CSI_HEADER_SIZE_V1
+        source_mac = None
+    elif magic == MAGIC_CSI_RAW_V2:
+        if len(data) < RAW_CSI_HEADER_SIZE_V2:
+            return None
+        header_size = RAW_CSI_HEADER_SIZE_V2
+        source_mac = ":".join(f"{b:02x}" for b in data[20:26])
+    else:
         return None
 
-    # Subcarrier data follows header as int16 I/Q pairs
-    payload_offset = RAW_CSI_HDR_SIZE
-    expected_bytes = n_sub * 2 * 2  # n_sub * (I + Q) * int16
-    if len(data) < payload_offset + expected_bytes:
+    node_id = data[4]
+    n_antennas = data[5]
+    n_sub = struct.unpack_from("<H", data, 6)[0]
+    if (
+        n_antennas == 0 or n_antennas > RAW_CSI_MAX_ANTENNAS or
+        n_sub == 0 or n_sub > RAW_CSI_MAX_SUBCARRIERS
+    ):
         return None
 
-    iq_data = struct.unpack_from(f"<{n_sub * 2}h", data, payload_offset)
-    # Convert I/Q pairs to amplitude
+    freq_mhz = struct.unpack_from("<I", data, 8)[0]
+    seq = struct.unpack_from("<I", data, 12)[0]
+    rssi = struct.unpack_from("<b", data, 16)[0]
+    noise = struct.unpack_from("<b", data, 17)[0]
+
+    expected_bytes = n_sub * n_antennas * 2
+    if len(data) < header_size + expected_bytes:
+        return None
+
+    def channel_from_freq_mhz(freq: int) -> int:
+        if 2412 <= freq <= 2472:
+            return round((freq - 2412) / 5) + 1
+        if freq == 2484:
+            return 14
+        if freq >= 5005:
+            return round((freq - 5000) / 5)
+        return 0
+
+    iq_data = data[header_size:header_size + expected_bytes]
     subcarriers = []
-    for i in range(0, len(iq_data), 2):
-        real, imag = iq_data[i], iq_data[i + 1]
+    for i in range(0, n_sub * 2, 2):
+        real = struct.unpack_from("<b", iq_data, i)[0]
+        imag = struct.unpack_from("<b", iq_data, i + 1)[0]
         amplitude = (real ** 2 + imag ** 2) ** 0.5
         subcarriers.append(amplitude)
 
-    return {
+    frame = {
         "type": "raw_csi",
         "node_id": node_id,
-        "antenna_config": ant_cfg,
+        "antenna_config": n_antennas,
         "n_subcarriers": n_sub,
-        "channel": channel,
-        "timestamp": ts_ms / 1000.0,
+        "channel": channel_from_freq_mhz(freq_mhz),
+        "freq_mhz": freq_mhz,
+        "sequence": seq,
+        "timestamp": time.time(),
         "subcarriers": subcarriers,
         "rssi": float(rssi),
         "noise_floor": float(noise),
     }
+    if source_mac is not None:
+        frame["source_mac"] = source_mac
+    return frame
 
 
 # ── JSONL recording ──────────────────────────────────────────────────────────

--- a/scripts/csi-graph-visualizer.js
+++ b/scripts/csi-graph-visualizer.js
@@ -25,6 +25,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -54,9 +55,6 @@ const VAR_FLOOR      = parseFloat(args['var-floor']);
 const MODE           = args.mode; // 'all', 'heatmap', 'clusters', 'spectrum'
 const TARGET_NODE    = parseInt(args.node, 10);
 const WIDTH          = parseInt(args.width, 10);
-
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
 
 // Color palette for person clusters (ANSI 256)
 const PERSON_COLORS = [
@@ -554,20 +552,14 @@ function parseIqHex(iqHex, nSubcarriers) {
 }
 
 function parseUdpPacket(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-  const nodeId       = buf.readUInt8(4);
-  const nSubcarriers = buf.readUInt16LE(6);
-  const amplitudes = new Float64Array(nSubcarriers);
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-  }
-  return { nodeId, nSubcarriers, amplitudes, timestamp: Date.now() };
+  const frame = parseRawCsiFrame(buf, { includePhase: false });
+  if (!frame) return null;
+  return {
+    nodeId: frame.nodeId,
+    nSubcarriers: frame.nSubcarriers,
+    amplitudes: frame.amplitudes,
+    timestamp: Date.now(),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/csi-spectrogram.js
+++ b/scripts/csi-spectrogram.js
@@ -27,6 +27,7 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -58,9 +59,7 @@ const LIMIT = args.limit ? parseInt(args.limit, 10) : Infinity;
 const PORT = parseInt(args.port, 10);
 const JSON_OUTPUT = args.json;
 
-// ADR-018 packet constants
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
+// ADR-018 raw CSI parser
 
 // CNN input size (ruvector/cnn expects 224x224 RGB)
 const CNN_INPUT_SIZE = 224;
@@ -97,27 +96,14 @@ function parseIqHex(iqHex, nSubcarriers) {
  * @returns {{ nodeId: number, rssi: number, nSubcarriers: number, amplitudes: Float32Array } | null}
  */
 function parseBinaryFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const rssi = buf.readInt8(5);
-  const nSubcarriers = buf.readUInt16LE(6);
-  const payloadSize = buf.readUInt16LE(8);
-
-  if (buf.length < HEADER_SIZE + payloadSize) return null;
-
-  const amps = new Float32Array(nSubcarriers);
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const off = HEADER_SIZE + sc * 2;
-    if (off + 2 > buf.length) break;
-    const iVal = buf[off];
-    const qVal = buf[off + 1];
-    amps[sc] = Math.sqrt(iVal * iVal + qVal * qVal);
-  }
-
-  return { nodeId, rssi, nSubcarriers, amplitudes: amps };
+  const frame = parseRawCsiFrame(buf, { includePhase: false });
+  if (!frame) return null;
+  return {
+    nodeId: frame.nodeId,
+    rssi: frame.rssi,
+    nSubcarriers: frame.nSubcarriers,
+    amplitudes: Float32Array.from(frame.amplitudes),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/deep-scan.js
+++ b/scripts/deep-scan.js
@@ -7,6 +7,7 @@
 
 const dgram = require('dgram');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 const { values: args } = parseArgs({
   options: {
@@ -29,20 +30,22 @@ const server = dgram.createSocket('udp4');
 
 server.on('message', (buf, rinfo) => {
   if (buf.length < 5) return;
+  const rawFrame = parseRawCsiFrame(buf, { includePhase: false });
+  if (rawFrame) {
+    if (!raw[rawFrame.nodeId]) raw[rawFrame.nodeId] = [];
+    raw[rawFrame.nodeId].push({
+      time: Date.now(),
+      amps: [...rawFrame.amplitudes],
+      rssi: rawFrame.rssi,
+      nSub: rawFrame.nSubcarriers,
+    });
+    return;
+  }
+
   const magic = buf.readUInt32LE(0);
   const nid = buf[4];
 
-  if (magic === 0xC5110001 && buf.length > 20) {
-    const iq = buf.subarray(20);
-    const nSub = Math.floor(iq.length / 2);
-    const amps = [];
-    for (let i = 0; i < nSub * 2 && i < iq.length - 1; i += 2) {
-      const I = iq.readInt8(i), Q = iq.readInt8(i + 1);
-      amps.push(Math.sqrt(I * I + Q * Q));
-    }
-    if (!raw[nid]) raw[nid] = [];
-    raw[nid].push({ time: Date.now(), amps, rssi: buf.readInt8(5), nSub });
-  } else if (magic === 0xC5110002 && buf.length >= 32) {
+  if (magic === 0xC5110002 && buf.length >= 32) {
     const br = buf.readUInt16LE(6) / 100;
     const hr = buf.readUInt32LE(8) / 10000;
     const rssi = buf.readInt8(12);

--- a/scripts/device-fingerprint.js
+++ b/scripts/device-fingerprint.js
@@ -31,6 +31,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -58,9 +59,6 @@ const JSON_OUTPUT = args.json;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
-
 const CHANNEL_FREQ = {};
 for (let ch = 1; ch <= 13; ch++) CHANNEL_FREQ[ch] = 2412 + (ch - 1) * 5;
 
@@ -391,29 +389,7 @@ function parseIqHex(iqHex, nSubcarriers) {
 }
 
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz = buf.readUInt32LE(8);
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-  }
-
-  let channel = 0;
-  if (freqMhz >= 2412 && freqMhz <= 2484) {
-    channel = freqMhz === 2484 ? 14 : Math.round((freqMhz - 2412) / 5) + 1;
-  }
-
-  return { nodeId, nSubcarriers, freqMhz, amplitudes, channel };
+  return parseRawCsiFrame(buf, { includePhase: false });
 }
 
 const nodeChannelIdx = { 1: 0, 2: 0 };
@@ -560,10 +536,6 @@ function startLive() {
   const sock = dgram.createSocket('udp4');
 
   sock.on('message', (buf) => {
-    if (buf.length < 4) return;
-    const magic = buf.readUInt32LE(0);
-    if (magic !== CSI_MAGIC) return;
-
     const frame = parseCSIFrame(buf);
     if (!frame) return;
 

--- a/scripts/gait-analyzer.js
+++ b/scripts/gait-analyzer.js
@@ -22,6 +22,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -43,10 +44,8 @@ const INTERVAL_MS = parseInt(args.interval, 10);
 // ---------------------------------------------------------------------------
 // ADR-018 packet constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC    = 0xC5110001;
 const VITALS_MAGIC = 0xC5110002;
 const FUSED_MAGIC  = 0xC5110004;
-const HEADER_SIZE  = 20;
 
 // ---------------------------------------------------------------------------
 // Simple FFT (radix-2 DIT)
@@ -347,20 +346,12 @@ function parseVitalsUdp(buf) {
 }
 
 function parseCsiUdp(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const nSc = buf.readUInt16LE(6);
+  const frame = parseRawCsiFrame(buf);
+  if (!frame) return null;
 
   let phaseSum = 0, phaseSqSum = 0, count = 0;
-  for (let sc = 0; sc < nSc; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    const phase = Math.atan2(Q, I);
+  for (let sc = 0; sc < frame.nSubcarriers; sc++) {
+    const phase = frame.phases[sc];
     phaseSum += phase;
     phaseSqSum += phase * phase;
     count++;
@@ -369,7 +360,11 @@ function parseCsiUdp(buf) {
   const phaseMean = count > 0 ? phaseSum / count : 0;
   const phaseVar = count > 1 ? (phaseSqSum / count - phaseMean * phaseMean) : 0;
 
-  return { timestamp: Date.now() / 1000, nodeId, phaseVar: Math.abs(phaseVar) };
+  return {
+    timestamp: Date.now() / 1000,
+    nodeId: frame.nodeId,
+    phaseVar: Math.abs(phaseVar),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/lib/raw-csi.js
+++ b/scripts/lib/raw-csi.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const CSI_MAGIC_V1 = 0xC5110001;
+const CSI_MAGIC_V2 = 0xC5110006;
+const CSI_HEADER_SIZE_V1 = 20;
+const CSI_HEADER_SIZE_V2 = 26;
+const MAX_ANTENNAS = 4;
+const MAX_SUBCARRIERS = 256;
+
+function channelFromFreqMhz(freqMhz) {
+  if (freqMhz >= 2412 && freqMhz <= 2472) {
+    return Math.round((freqMhz - 2412) / 5) + 1;
+  }
+  if (freqMhz === 2484) {
+    return 14;
+  }
+  if (freqMhz >= 5005) {
+    return Math.round((freqMhz - 5000) / 5);
+  }
+  return 0;
+}
+
+function formatSourceMac(buf, offset) {
+  return Array.from(buf.subarray(offset, offset + 6), (byte) =>
+    byte.toString(16).padStart(2, '0')).join(':');
+}
+
+function getRawCsiLayout(buf) {
+  if (!Buffer.isBuffer(buf) || buf.length < CSI_HEADER_SIZE_V1) {
+    return null;
+  }
+
+  const magic = buf.readUInt32LE(0);
+  if (magic === CSI_MAGIC_V1) {
+    return { magic, headerSize: CSI_HEADER_SIZE_V1, sourceMac: null };
+  }
+
+  if (magic !== CSI_MAGIC_V2 || buf.length < CSI_HEADER_SIZE_V2) {
+    return null;
+  }
+
+  const nAntennas = buf.readUInt8(5);
+  const nSubcarriers = buf.readUInt16LE(6);
+  if (
+    nAntennas === 0 || nAntennas > MAX_ANTENNAS ||
+    nSubcarriers === 0 || nSubcarriers > MAX_SUBCARRIERS
+  ) {
+    return null;
+  }
+
+  const expectedLength = CSI_HEADER_SIZE_V2 + nAntennas * nSubcarriers * 2;
+  if (buf.length < expectedLength) {
+    return null;
+  }
+
+  return {
+    magic,
+    headerSize: CSI_HEADER_SIZE_V2,
+    sourceMac: formatSourceMac(buf, 20),
+  };
+}
+
+function parseRawCsiFrame(buf, { includePhase = true } = {}) {
+  const layout = getRawCsiLayout(buf);
+  if (!layout) {
+    return null;
+  }
+
+  const nodeId = buf.readUInt8(4);
+  const nAntennas = buf.readUInt8(5);
+  const nSubcarriers = buf.readUInt16LE(6);
+  const freqMhz = buf.readUInt32LE(8);
+  const seq = buf.readUInt32LE(12);
+  const rssiRaw = buf.readInt8(16);
+  const noiseFloor = buf.readInt8(17);
+  const iqLength = nAntennas * nSubcarriers * 2;
+  const expectedLength = layout.headerSize + iqLength;
+
+  if (
+    nAntennas === 0 || nAntennas > MAX_ANTENNAS ||
+    nSubcarriers === 0 || nSubcarriers > MAX_SUBCARRIERS ||
+    buf.length < expectedLength
+  ) {
+    return null;
+  }
+
+  const amplitudes = new Float64Array(nSubcarriers);
+  const phases = includePhase ? new Float64Array(nSubcarriers) : null;
+
+  for (let sc = 0; sc < nSubcarriers; sc++) {
+    const offset = layout.headerSize + sc * 2;
+    const iVal = buf.readInt8(offset);
+    const qVal = buf.readInt8(offset + 1);
+    amplitudes[sc] = Math.sqrt(iVal * iVal + qVal * qVal);
+    if (phases) {
+      phases[sc] = Math.atan2(qVal, iVal);
+    }
+  }
+
+  return {
+    magic: layout.magic,
+    nodeId,
+    nAntennas,
+    nSubcarriers,
+    freqMhz,
+    seq,
+    rssi: rssiRaw > 0 ? -rssiRaw : rssiRaw,
+    noiseFloor,
+    sourceMac: layout.sourceMac,
+    headerSize: layout.headerSize,
+    channel: channelFromFreqMhz(freqMhz),
+    amplitudes,
+    phases,
+  };
+}
+
+module.exports = {
+  CSI_MAGIC_V1,
+  CSI_MAGIC_V2,
+  CSI_HEADER_SIZE_V1,
+  CSI_HEADER_SIZE_V2,
+  channelFromFreqMhz,
+  getRawCsiLayout,
+  parseRawCsiFrame,
+};

--- a/scripts/material-classifier.js
+++ b/scripts/material-classifier.js
@@ -29,6 +29,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -54,9 +55,6 @@ const WINDOW_FRAMES = parseInt(args.window, 10);
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
-
 const CHANNEL_FREQ = {};
 for (let ch = 1; ch <= 13; ch++) CHANNEL_FREQ[ch] = 2412 + (ch - 1) * 5;
 
@@ -302,29 +300,7 @@ function parseIqHex(iqHex, nSubcarriers) {
 }
 
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz = buf.readUInt32LE(8);
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-  }
-
-  let channel = 0;
-  if (freqMhz >= 2412 && freqMhz <= 2484) {
-    channel = freqMhz === 2484 ? 14 : Math.round((freqMhz - 2412) / 5) + 1;
-  }
-
-  return { nodeId, nSubcarriers, freqMhz, amplitudes, channel };
+  return parseRawCsiFrame(buf, { includePhase: false });
 }
 
 const nodeChannelIdx = { 1: 0, 2: 0 };
@@ -508,10 +484,6 @@ function startLive() {
   const sock = dgram.createSocket('udp4');
 
   sock.on('message', (buf) => {
-    if (buf.length < 4) return;
-    const magic = buf.readUInt32LE(0);
-    if (magic !== CSI_MAGIC) return;
-
     const frame = parseCSIFrame(buf);
     if (!frame) return;
 

--- a/scripts/material-detector.js
+++ b/scripts/material-detector.js
@@ -20,6 +20,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -45,10 +46,7 @@ const NULL_THRESHOLD   = parseFloat(args['null-threshold']);
 const CHANGE_THRESHOLD = parseInt(args['change-threshold'], 10); // min subcarriers changed
 
 // ---------------------------------------------------------------------------
-// ADR-018 packet constants
-// ---------------------------------------------------------------------------
-const CSI_MAGIC   = 0xC5110001;
-const HEADER_SIZE = 20;
+// ADR-018 raw CSI parser
 
 // ---------------------------------------------------------------------------
 // Subcarrier null pattern tracker
@@ -292,23 +290,13 @@ function parseCsiJsonl(record) {
 }
 
 function parseCsiUdp(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const nSc = buf.readUInt16LE(6);
-  const amplitudes = new Float64Array(nSc);
-
-  for (let sc = 0; sc < nSc; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-  }
-
-  return { timestamp: Date.now() / 1000, nodeId, amplitudes };
+  const frame = parseRawCsiFrame(buf, { includePhase: false });
+  if (!frame) return null;
+  return {
+    timestamp: Date.now() / 1000,
+    nodeId: frame.nodeId,
+    amplitudes: frame.amplitudes,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/mesh-graph-transformer.js
+++ b/scripts/mesh-graph-transformer.js
@@ -32,6 +32,7 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -57,9 +58,7 @@ const PORT = parseInt(args.port, 10);
 const LIMIT = args.limit ? parseInt(args.limit, 10) : Infinity;
 const JSON_OUTPUT = args.json;
 
-// ADR-018 packet constants
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
+// ADR-018 raw CSI parser
 
 // ---------------------------------------------------------------------------
 // IQ Parsing (shared with csi-spectrogram.js)
@@ -570,16 +569,12 @@ async function processLive() {
     let nodeId, nSubcarriers, amplitudes, rssi;
 
     // Try binary ADR-018 format
-    if (msg.length >= HEADER_SIZE && msg.readUInt32LE(0) === CSI_MAGIC) {
-      nodeId = msg.readUInt8(4);
-      rssi = msg.readInt8(5);
-      nSubcarriers = msg.readUInt16LE(6);
-      amplitudes = new Float32Array(nSubcarriers);
-      for (let sc = 0; sc < nSubcarriers; sc++) {
-        const off = HEADER_SIZE + sc * 2;
-        if (off + 2 > msg.length) break;
-        amplitudes[sc] = Math.sqrt(msg[off] ** 2 + msg[off + 1] ** 2);
-      }
+    const csiFrame = parseRawCsiFrame(msg, { includePhase: false });
+    if (csiFrame) {
+      nodeId = csiFrame.nodeId;
+      rssi = csiFrame.rssi;
+      nSubcarriers = csiFrame.nSubcarriers;
+      amplitudes = Float32Array.from(csiFrame.amplitudes);
     } else {
       // Try JSONL
       try {

--- a/scripts/mincut-person-counter.js
+++ b/scripts/mincut-person-counter.js
@@ -29,6 +29,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -60,10 +61,7 @@ const JSON_OUTPUT     = args.json;
 const FORWARD_PORT    = args.forward ? parseInt(args.forward, 10) : null;
 
 // ---------------------------------------------------------------------------
-// ADR-018 packet constants
-// ---------------------------------------------------------------------------
-const CSI_MAGIC    = 0xC5110001;
-const HEADER_SIZE  = 20;
+// ADR-018 raw CSI parser
 
 // ---------------------------------------------------------------------------
 // Per-node sliding window of subcarrier amplitudes
@@ -472,28 +470,16 @@ function parseIqHex(iqHex, nSubcarriers) {
 
 /** Parse binary UDP CSI packet (ADR-018 format) */
 function parseUdpPacket(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId       = buf.readUInt8(4);
-  const nAntennas    = buf.readUInt8(5) || 1;
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz      = buf.readUInt32LE(8);
-  const rssi         = buf.readInt8(16);
-
-  const iqLen = nSubcarriers * nAntennas * 2;
-  if (buf.length < HEADER_SIZE + iqLen) return null;
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-  }
-
-  return { nodeId, nSubcarriers, freqMhz, rssi, amplitudes, timestamp: Date.now() / 1000 };
+  const frame = parseRawCsiFrame(buf, { includePhase: false });
+  if (!frame) return null;
+  return {
+    nodeId: frame.nodeId,
+    nSubcarriers: frame.nSubcarriers,
+    freqMhz: frame.freqMhz,
+    rssi: frame.rssi,
+    amplitudes: frame.amplitudes,
+    timestamp: Date.now() / 1000,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/passive-radar.js
+++ b/scripts/passive-radar.js
@@ -29,6 +29,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -58,8 +59,6 @@ const RANGE_BINS = parseInt(args['range-bins'], 10);
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
 const SPEED_OF_LIGHT = 3e8; // m/s
 
 const CHANNEL_FREQ = {};
@@ -383,33 +382,7 @@ function parseIqHex(iqHex, nSubcarriers) {
 }
 
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz = buf.readUInt32LE(8);
-  const rssi = buf.readInt8(16);
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  const phases = new Float64Array(nSubcarriers);
-
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-    phases[sc] = Math.atan2(Q, I);
-  }
-
-  let channel = 0;
-  if (freqMhz >= 2412 && freqMhz <= 2484) {
-    channel = freqMhz === 2484 ? 14 : Math.round((freqMhz - 2412) / 5) + 1;
-  }
-
-  return { nodeId, nSubcarriers, freqMhz, rssi, amplitudes, phases, channel };
+  return parseRawCsiFrame(buf);
 }
 
 // Channel assignment for legacy JSONL
@@ -548,10 +521,6 @@ function startLive() {
   const sock = dgram.createSocket('udp4');
 
   sock.on('message', (buf, rinfo) => {
-    if (buf.length < 4) return;
-    const magic = buf.readUInt32LE(0);
-    if (magic !== CSI_MAGIC) return;
-
     const frame = parseCSIFrame(buf);
     if (!frame) return;
 

--- a/scripts/record-csi-udp.py
+++ b/scripts/record-csi-udp.py
@@ -18,38 +18,79 @@ import time
 
 
 def parse_csi_packet(data):
-    """Parse ADR-018 binary CSI packet into dict."""
-    if len(data) < 8:
+    """Parse ADR-018 V1/V2 binary CSI packet into dict.
+
+    V1 (magic 0xC5110001): 20-byte header, no source MAC.
+    V2 (magic 0xC5110003): 26-byte header, 6-byte source MAC at offset 20.
+
+    Header layout:
+        [0..3]   Magic (u32 LE)
+        [4]      Node ID (u8)
+        [5]      N antennas (u8)
+        [6..7]   N subcarriers (u16 LE)
+        [8..11]  Frequency MHz (u32 LE)
+        [12..15] Sequence (u32 LE)
+        [16]     RSSI (i8)
+        [17]     Noise floor (i8)
+        [18..19] Reserved
+        [20..25] Source MAC (V2 only)
+        [20/26+] I/Q data (i8, i8 pairs)
+    """
+    if len(data) < 20:
         return None
 
-    # ADR-018 header: [magic(2), len(2), node_id(1), seq(1), rssi(1), channel(1), iq_data...]
-    # Simplified: extract what we can from the raw packet
-    node_id = data[4] if len(data) > 4 else 0
-    rssi = struct.unpack('b', bytes([data[6]]))[0] if len(data) > 6 else 0
-    channel = data[7] if len(data) > 7 else 0
+    magic = struct.unpack('<I', data[0:4])[0]
 
-    # IQ data starts at offset 8
-    iq_data = data[8:] if len(data) > 8 else b''
-    n_subcarriers = len(iq_data) // 2  # I,Q pairs
+    if magic == 0xC5110001:
+        header_size = 20
+        source_mac = None
+    elif magic == 0xC5110003:
+        if len(data) < 26:
+            return None
+        header_size = 26
+        source_mac = ':'.join(f'{b:02x}' for b in data[20:26])
+    else:
+        return None
 
-    # Compute amplitudes
+    node_id = data[4]
+    n_antennas = data[5]
+    n_subcarriers = struct.unpack('<H', data[6:8])[0]
+    freq_mhz = struct.unpack('<I', data[8:12])[0]
+    sequence = struct.unpack('<I', data[12:16])[0]
+    rssi = struct.unpack('b', bytes([data[16]]))[0]
+    noise_floor = struct.unpack('b', bytes([data[17]]))[0]
+
+    iq_data = data[header_size:]
+    n_pairs = n_antennas * n_subcarriers
+    expected_iq = n_pairs * 2
+    if len(iq_data) < expected_iq:
+        return None
+
     amplitudes = []
-    for i in range(0, len(iq_data) - 1, 2):
+    for i in range(0, expected_iq, 2):
         I = struct.unpack('b', bytes([iq_data[i]]))[0]
         Q = struct.unpack('b', bytes([iq_data[i + 1]]))[0]
         amplitudes.append(round((I * I + Q * Q) ** 0.5, 2))
 
-    return {
+    result = {
         "type": "raw_csi",
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.") + f"{int(time.time() * 1000) % 1000:03d}Z",
         "ts_ns": time.time_ns(),
         "node_id": node_id,
+        "n_antennas": n_antennas,
+        "n_subcarriers": n_subcarriers,
+        "freq_mhz": freq_mhz,
+        "sequence": sequence,
         "rssi": rssi,
-        "channel": channel,
-        "subcarriers": n_subcarriers,
+        "noise_floor": noise_floor,
+        "subcarriers": len(amplitudes),
         "amplitudes": amplitudes,
-        "iq_hex": iq_data.hex(),
+        "iq_hex": iq_data[:expected_iq].hex(),
     }
+    if source_mac is not None:
+        result["source_mac"] = source_mac
+
+    return result
 
 
 def main():

--- a/scripts/record-csi-udp.py
+++ b/scripts/record-csi-udp.py
@@ -21,7 +21,7 @@ def parse_csi_packet(data):
     """Parse ADR-018 V1/V2 binary CSI packet into dict.
 
     V1 (magic 0xC5110001): 20-byte header, no source MAC.
-    V2 (magic 0xC5110003): 26-byte header, 6-byte source MAC at offset 20.
+    V2 (magic 0xC5110006): 26-byte header, 6-byte source MAC at offset 20.
 
     Header layout:
         [0..3]   Magic (u32 LE)
@@ -44,7 +44,7 @@ def parse_csi_packet(data):
     if magic == 0xC5110001:
         header_size = 20
         source_mac = None
-    elif magic == 0xC5110003:
+    elif magic == 0xC5110006:
         if len(data) < 26:
             return None
         header_size = 26

--- a/scripts/rf-scan-multifreq.js
+++ b/scripts/rf-scan-multifreq.js
@@ -26,6 +26,7 @@
 
 const dgram = require('dgram');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -48,11 +49,9 @@ const JSON_OUTPUT = args.json;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC     = 0xC5110001;
 const VITALS_MAGIC  = 0xC5110002;
 const FEATURE_MAGIC = 0xC5110003;
 const FUSED_MAGIC   = 0xC5110004;
-const HEADER_SIZE   = 20;
 
 const BARS = ['\u2581', '\u2582', '\u2583', '\u2584', '\u2585', '\u2586', '\u2587', '\u2588'];
 
@@ -238,44 +237,7 @@ let totalFrames = 0;
 // Packet parsing (same as rf-scan.js)
 // ---------------------------------------------------------------------------
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId       = buf.readUInt8(4);
-  const nAntennas    = buf.readUInt8(5) || 1;
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz      = buf.readUInt32LE(8);
-  const seq          = buf.readUInt32LE(12);
-  const rssi         = buf.readInt8(16);
-  const noiseFloor   = buf.readInt8(17);
-
-  const iqLen = nSubcarriers * nAntennas * 2;
-  if (buf.length < HEADER_SIZE + iqLen) return null;
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  const phases = new Float64Array(nSubcarriers);
-
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-    phases[sc] = Math.atan2(Q, I);
-  }
-
-  // Derive channel from frequency
-  let channel = 0;
-  if (freqMhz >= 2412 && freqMhz <= 2484) {
-    channel = freqMhz === 2484 ? 14 : Math.round((freqMhz - 2412) / 5) + 1;
-  } else if (freqMhz >= 5180) {
-    channel = Math.round((freqMhz - 5000) / 5);
-  }
-
-  return {
-    nodeId, nAntennas, nSubcarriers, freqMhz, seq, rssi, noiseFloor,
-    amplitudes, phases, channel,
-  };
+  return parseRawCsiFrame(buf);
 }
 
 function parseVitalsPacket(buf) {
@@ -311,12 +273,8 @@ function parseFeaturePacket(buf) {
 
 function handlePacket(buf, rinfo) {
   if (buf.length < 4) return;
-  const magic = buf.readUInt32LE(0);
-
-  if (magic === CSI_MAGIC) {
-    const frame = parseCSIFrame(buf);
-    if (!frame) return;
-
+  const frame = parseCSIFrame(buf);
+  if (frame) {
     totalFrames++;
     let node = nodes.get(frame.nodeId);
     if (!node) {
@@ -333,6 +291,8 @@ function handlePacket(buf, rinfo) {
     cs.update(frame.amplitudes, frame.phases);
     return;
   }
+
+  const magic = buf.readUInt32LE(0);
 
   if (magic === VITALS_MAGIC || magic === FUSED_MAGIC) {
     const vitals = parseVitalsPacket(buf);

--- a/scripts/rf-scan.js
+++ b/scripts/rf-scan.js
@@ -18,6 +18,7 @@
 
 const dgram = require('dgram');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -41,11 +42,9 @@ const JSON_OUTPUT = args.json;
 // ---------------------------------------------------------------------------
 // ADR-018 packet constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC     = 0xC5110001;
 const VITALS_MAGIC  = 0xC5110002;
 const FEATURE_MAGIC = 0xC5110003;
 const FUSED_MAGIC   = 0xC5110004;
-const HEADER_SIZE   = 20;
 
 // Spectrum visualization characters (8 levels)
 const BARS = ['\u2581', '\u2582', '\u2583', '\u2584', '\u2585', '\u2586', '\u2587', '\u2588'];
@@ -218,39 +217,7 @@ let totalFrames = 0;
 // Packet parsing
 // ---------------------------------------------------------------------------
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId       = buf.readUInt8(4);
-  const nAntennas    = buf.readUInt8(5) || 1;
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz      = buf.readUInt32LE(8);
-  const seq          = buf.readUInt32LE(12);
-  const rssi         = buf.readInt8(16);
-  const noiseFloor   = buf.readInt8(17);
-
-  const iqLen = nSubcarriers * nAntennas * 2;
-  if (buf.length < HEADER_SIZE + iqLen) return null;
-
-  // Extract amplitude and phase from I/Q pairs
-  const amplitudes = new Float64Array(nSubcarriers);
-  const phases = new Float64Array(nSubcarriers);
-
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    // Use first antenna for primary analysis
-    const offset = HEADER_SIZE + sc * 2;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-    phases[sc] = Math.atan2(Q, I);
-  }
-
-  return {
-    nodeId, nAntennas, nSubcarriers, freqMhz, seq, rssi, noiseFloor,
-    amplitudes, phases,
-  };
+  return parseRawCsiFrame(buf);
 }
 
 function parseVitalsPacket(buf) {
@@ -299,12 +266,8 @@ function parseFeaturePacket(buf) {
 function handlePacket(buf, rinfo) {
   // Try CSI frame first (most common)
   if (buf.length >= 4) {
-    const magic = buf.readUInt32LE(0);
-
-    if (magic === CSI_MAGIC) {
-      const frame = parseCSIFrame(buf);
-      if (!frame) return;
-
+    const frame = parseCSIFrame(buf);
+    if (frame) {
       totalFrames++;
       let node = nodes.get(frame.nodeId);
       if (!node) {
@@ -322,6 +285,8 @@ function handlePacket(buf, rinfo) {
       node.updateAmplitudes(frame.amplitudes, frame.phases);
       return;
     }
+
+    const magic = buf.readUInt32LE(0);
 
     if (magic === VITALS_MAGIC || magic === FUSED_MAGIC) {
       const vitals = parseVitalsPacket(buf);

--- a/scripts/rf-tomography.js
+++ b/scripts/rf-tomography.js
@@ -24,6 +24,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -55,9 +56,6 @@ const ROOM_HEIGHT = parseFloat(args['room-height']);
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
-
 const CHANNEL_FREQ = {};
 for (let ch = 1; ch <= 13; ch++) CHANNEL_FREQ[ch] = 2412 + (ch - 1) * 5;
 CHANNEL_FREQ[14] = 2484;
@@ -263,33 +261,7 @@ function parseIqHex(iqHex, nSubcarriers) {
 }
 
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz = buf.readUInt32LE(8);
-  const rssi = buf.readInt8(16);
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  const phases = new Float64Array(nSubcarriers);
-
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-    phases[sc] = Math.atan2(Q, I);
-  }
-
-  let channel = 0;
-  if (freqMhz >= 2412 && freqMhz <= 2484) {
-    channel = freqMhz === 2484 ? 14 : Math.round((freqMhz - 2412) / 5) + 1;
-  }
-
-  return { nodeId, nSubcarriers, freqMhz, rssi, amplitudes, phases, channel };
+  return parseRawCsiFrame(buf);
 }
 
 /**
@@ -473,10 +445,6 @@ function startLive() {
   const sock = dgram.createSocket('udp4');
 
   sock.on('message', (buf, rinfo) => {
-    if (buf.length < 4) return;
-    const magic = buf.readUInt32LE(0);
-    if (magic !== CSI_MAGIC) return;
-
     const frame = parseCSIFrame(buf);
     if (!frame) return;
 

--- a/scripts/seed_csi_bridge.py
+++ b/scripts/seed_csi_bridge.py
@@ -23,7 +23,7 @@ Usage:
     # Trigger store compaction
     python scripts/seed_csi_bridge.py --token TOKEN --compact
 
-The bridge also accepts legacy ADR-018 CSI frames (magic 0xC5110001/0xC5110002)
+The bridge also accepts ADR-018 CSI frames (V1/V2) plus vitals packets
 and extracts a simplified 8-dim feature vector from the raw data.
 """
 
@@ -51,9 +51,14 @@ logging.basicConfig(
 log = logging.getLogger("seed-bridge")
 
 # Packet magic numbers
-MAGIC_CSI_RAW   = 0xC5110001  # ADR-018 raw CSI frame
+MAGIC_CSI_RAW_V1 = 0xC5110001  # ADR-018 raw CSI frame (V1)
+MAGIC_CSI_RAW_V2 = 0xC5110006  # ADR-018 raw CSI frame (V2, source MAC)
 MAGIC_VITALS    = 0xC5110002  # ADR-039 vitals packet
 MAGIC_FEATURES  = 0xC5110003  # ADR-069 feature vector (new)
+RAW_CSI_HEADER_SIZE_V1 = 20
+RAW_CSI_HEADER_SIZE_V2 = 26
+RAW_CSI_MAX_ANTENNAS = 4
+RAW_CSI_MAX_SUBCARRIERS = 256
 
 # Feature vector packet: 4 + 1 + 1 + 2 + 8 + 32 = 48 bytes
 FEATURE_PKT_FMT = "<IBBHq8f"
@@ -148,20 +153,40 @@ def parse_vitals_packet(data: bytes) -> dict | None:
 
 
 def parse_raw_csi_packet(data: bytes) -> dict | None:
-    """Parse an ADR-018 raw CSI frame and extract basic features."""
-    if len(data) < 8:
+    """Parse ADR-018 raw CSI frames (V1/V2) and extract basic features."""
+    if len(data) < RAW_CSI_HEADER_SIZE_V1:
         return None
+
     magic = struct.unpack_from("<I", data)[0]
-    if magic != MAGIC_CSI_RAW:
+    if magic == MAGIC_CSI_RAW_V1:
+        header_size = RAW_CSI_HEADER_SIZE_V1
+    elif magic == MAGIC_CSI_RAW_V2:
+        if len(data) < RAW_CSI_HEADER_SIZE_V2:
+            return None
+        header_size = RAW_CSI_HEADER_SIZE_V2
+    else:
         return None
-    # Extract node_id (byte 4) and RSSI (byte 5, signed)
-    node_id = data[4] if len(data) > 4 else 0
-    rssi = struct.unpack_from("b", data, 5)[0] if len(data) > 5 else -70
+
+    node_id = data[4]
+    n_antennas = data[5]
+    n_subcarriers = struct.unpack_from("<H", data, 6)[0]
+    if (
+        n_antennas == 0 or n_antennas > RAW_CSI_MAX_ANTENNAS or
+        n_subcarriers == 0 or n_subcarriers > RAW_CSI_MAX_SUBCARRIERS
+    ):
+        return None
+
+    expected_len = header_size + n_antennas * n_subcarriers * 2
+    if len(data) < expected_len:
+        return None
+
+    rssi = struct.unpack_from("<b", data, 16)[0]
+    seq = struct.unpack_from("<I", data, 12)[0]
     # Minimal feature vector from raw CSI -- mostly placeholder
     features = [0.5, 0.5, 0.0, 0.0, 0.5, 0.5, 0.0, max(0.0, min(1.0, (rssi + 100) / 100.0))]
     return {
         "node_id": node_id,
-        "seq": 0,
+        "seq": seq,
         "timestamp_us": int(time.time() * 1_000_000),
         "features": features,
     }
@@ -185,13 +210,16 @@ def parse_packet(data: bytes) -> dict | None:
     """Try all packet formats."""
     if len(data) < 4:
         return None
+
+    raw_packet = parse_raw_csi_packet(data)
+    if raw_packet is not None:
+        return _validate_features(raw_packet)
+
     magic = struct.unpack_from("<I", data)[0]
     if magic == MAGIC_FEATURES:
         return _validate_features(parse_feature_packet(data))
     elif magic == MAGIC_VITALS:
         return _validate_features(parse_vitals_packet(data))
-    elif magic == MAGIC_CSI_RAW:
-        return _validate_features(parse_raw_csi_packet(data))
     return None
 
 

--- a/scripts/snn-csi-processor.js
+++ b/scripts/snn-csi-processor.js
@@ -30,6 +30,7 @@
 
 const dgram = require('dgram');
 const path = require('path');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // Resolve spiking-neural: try npm, then vendor
@@ -100,48 +101,19 @@ function parseArgs() {
 // ---------------------------------------------------------------------------
 // ADR-018 binary frame parser
 // ---------------------------------------------------------------------------
-const HEADER_SIZE = 20;
-
 function parseFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-
-  const magic = buf.readUInt32LE(0);
-  // ADR-018 magic: 0xC5110001 (raw CSI), 0xC5110002 (vitals), 0xC5110003 (features)
-  if (magic !== 0xC5110001 && magic !== 0xC5110002 && magic !== 0xC5110003) return null;
-
-  const version = buf.readUInt8(2);
-  const flags = buf.readUInt8(3);
-  const timestamp = buf.readUInt32LE(4);
-  const frequency = buf.readUInt32LE(8);
-  const rssi = buf.readInt8(12);
-  const noiseFloor = buf.readInt8(13);
-  const numSubcarriers = buf.readUInt16LE(14);
-  const nodeId = buf.readUInt16LE(16);
-  const seqNum = buf.readUInt16LE(18);
-
-  const expectedPayload = numSubcarriers * 4; // 2 bytes I + 2 bytes Q per subcarrier
-  if (buf.length < HEADER_SIZE + expectedPayload) {
-    // Fallback: try 2 bytes per subcarrier (amplitude only)
-    if (buf.length >= HEADER_SIZE + numSubcarriers * 2) {
-      const amplitudes = new Float32Array(numSubcarriers);
-      for (let i = 0; i < numSubcarriers; i++) {
-        amplitudes[i] = buf.readInt16LE(HEADER_SIZE + i * 2);
-      }
-      return { timestamp, frequency, rssi, noiseFloor, numSubcarriers, nodeId, seqNum, amplitudes };
-    }
-    return null;
-  }
-
-  // Parse I/Q and compute amplitudes
-  const amplitudes = new Float32Array(numSubcarriers);
-  for (let i = 0; i < numSubcarriers; i++) {
-    const offset = HEADER_SIZE + i * 4;
-    const real = buf.readInt16LE(offset);
-    const imag = buf.readInt16LE(offset + 2);
-    amplitudes[i] = Math.sqrt(real * real + imag * imag);
-  }
-
-  return { timestamp, frequency, rssi, noiseFloor, numSubcarriers, nodeId, seqNum, amplitudes };
+  const frame = parseRawCsiFrame(buf, { includePhase: false });
+  if (!frame) return null;
+  return {
+    timestamp: Date.now(),
+    frequency: frame.freqMhz,
+    rssi: frame.rssi,
+    noiseFloor: frame.noiseFloor,
+    numSubcarriers: frame.nSubcarriers,
+    nodeId: frame.nodeId,
+    seqNum: frame.seq,
+    amplitudes: Float32Array.from(frame.amplitudes),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/through-wall-detector.js
+++ b/scripts/through-wall-detector.js
@@ -29,6 +29,7 @@ const dgram = require('dgram');
 const fs = require('fs');
 const readline = require('readline');
 const { parseArgs } = require('util');
+const { parseRawCsiFrame } = require('./lib/raw-csi');
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -58,9 +59,6 @@ const JSON_OUTPUT = args.json;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-const CSI_MAGIC = 0xC5110001;
-const HEADER_SIZE = 20;
-
 const CHANNEL_FREQ = {};
 for (let ch = 1; ch <= 13; ch++) CHANNEL_FREQ[ch] = 2412 + (ch - 1) * 5;
 
@@ -318,29 +316,7 @@ function parseIqHex(iqHex, nSubcarriers) {
 }
 
 function parseCSIFrame(buf) {
-  if (buf.length < HEADER_SIZE) return null;
-  const magic = buf.readUInt32LE(0);
-  if (magic !== CSI_MAGIC) return null;
-
-  const nodeId = buf.readUInt8(4);
-  const nSubcarriers = buf.readUInt16LE(6);
-  const freqMhz = buf.readUInt32LE(8);
-
-  const amplitudes = new Float64Array(nSubcarriers);
-  for (let sc = 0; sc < nSubcarriers; sc++) {
-    const offset = HEADER_SIZE + sc * 2;
-    if (offset + 1 >= buf.length) break;
-    const I = buf.readInt8(offset);
-    const Q = buf.readInt8(offset + 1);
-    amplitudes[sc] = Math.sqrt(I * I + Q * Q);
-  }
-
-  let channel = 0;
-  if (freqMhz >= 2412 && freqMhz <= 2484) {
-    channel = freqMhz === 2484 ? 14 : Math.round((freqMhz - 2412) / 5) + 1;
-  }
-
-  return { nodeId, nSubcarriers, freqMhz, amplitudes, channel };
+  return parseRawCsiFrame(buf, { includePhase: false });
 }
 
 const nodeChannelIdx = { 1: 0, 2: 0 };
@@ -467,10 +443,6 @@ function startLive() {
   const sock = dgram.createSocket('udp4');
 
   sock.on('message', (buf) => {
-    if (buf.length < 4) return;
-    const magic = buf.readUInt32LE(0);
-    if (magic !== CSI_MAGIC) return;
-
     const frame = parseCSIFrame(buf);
     if (!frame) return;
 

--- a/scripts/validate_mesh_test.py
+++ b/scripts/validate_mesh_test.py
@@ -9,7 +9,7 @@ Parses the aggregator results JSON and per-node UART logs, then runs 6 checks:
   2. TDM ordering              - slot assignments are sequential 0..N-1
   3. No slot collision         - no two nodes share a TDM slot
   4. Frame count balance       - per-node frame counts within +/-10%
-  5. ADR-018 compliance        - magic 0xC5110001 present in frames
+  5. ADR-018 compliance        - raw CSI magic 0xC5110001/0xC5110006 present in frames
   6. Vitals per node           - each node produced vitals output
 
 Usage:
@@ -365,14 +365,14 @@ def validate_mesh(
         report.add("Frame count balance", Severity.WARN,
                     "No frame count data found")
 
-    # ---- Check 5: ADR-018 compliance (magic 0xC5110001) ----
-    ADR018_MAGIC = "c5110001"
+    # ---- Check 5: ADR-018 compliance (magic 0xC5110001 or 0xC5110006) ----
+    ADR018_MAGICS = ("c5110001", "c5110006")
     magic_found = False
 
     # Check aggregator results
     if results:
         results_str = json.dumps(results).lower()
-        if ADR018_MAGIC in results_str or "0xc5110001" in results_str:
+        if any(magic in results_str for magic in ADR018_MAGICS) or "0xc5110001" in results_str or "0xc5110006" in results_str:
             magic_found = True
         # Also check a dedicated field
         if results.get("adr018_magic") or results.get("magic"):
@@ -381,9 +381,9 @@ def validate_mesh(
         if "nodes" in results:
             for node_entry in results["nodes"]:
                 magic = node_entry.get("magic", "")
-                if isinstance(magic, str) and ADR018_MAGIC in magic.lower():
+                if isinstance(magic, str) and any(candidate in magic.lower() for candidate in ADR018_MAGICS):
                     magic_found = True
-                elif isinstance(magic, int) and magic == 0xC5110001:
+                elif isinstance(magic, int) and magic in (0xC5110001, 0xC5110006):
                     magic_found = True
 
     # Check logs for serialization/ADR-018 markers
@@ -392,9 +392,12 @@ def validate_mesh(
             log_text = node_logs.get(idx, "")
             adr018_pats = [
                 r"0xC5110001",
+                r"0xC5110006",
                 r"c5110001",
+                r"c5110006",
                 r"ADR-018",
                 r"magic[=: ]+0x[Cc]5110001",
+                r"magic[=: ]+0x[Cc]5110006",
             ]
             if any(re.search(p, log_text, re.IGNORECASE) for p in adr018_pats):
                 magic_found = True
@@ -402,10 +405,10 @@ def validate_mesh(
 
     if magic_found:
         report.add("ADR-018 compliance", Severity.PASS,
-                    "Magic 0xC5110001 found in frame data")
+                    "ADR-018 raw CSI magic found in frame data")
     else:
         report.add("ADR-018 compliance", Severity.WARN,
-                    "Magic 0xC5110001 not found (may require deeper frame inspection)")
+                    "ADR-018 raw CSI magic not found (may require deeper frame inspection)")
 
     # ---- Check 6: Vitals per node ----
     vitals_nodes = []


### PR DESCRIPTION
## Summary

- extend ADR-018 binary frame format with a 6-byte source MAC at offset 20 using V2 magic `0xC5110006` and a 26-byte header
- preserve backward compatibility by teaching the raw CSI JS and Python tooling to accept both V1 and V2 frames through a shared decoder in `scripts/lib/raw-csi.js`
- resolve the protocol collision with ADR-069 feature packets, which keep magic `0xC5110003`
- harden the sensing server parser so malformed packets with zero antennas or zero subcarriers are rejected instead of being treated as empty CSI

## Validation

- `node --check` on the touched JS scripts
- `python3 -m py_compile` on the touched Python scripts
- synthetic V1 and V2 sanity check for `scripts/lib/raw-csi.js`
- `cargo test -p wifi-densepose-hardware esp32_parser --no-default-features`
- `wifi-densepose-sensing-server` still has pre-existing unrelated build failures (`ruvector_mincut` imports, missing `adaptive_classifier::CLASSES`, and borrow checker errors in `main.rs`), so it could not be used as the final backstop
