### PR TITLE
fix: restore successful WSL release build for rust sensing server

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -103,6 +103,20 @@ Example: `docker run -e CSI_SOURCE=esp32 -p 3000:3000 -p 5005:5005/udp ruvnet/wi
 
 ### From Source (Rust)
 
+On Debian/Ubuntu-based Linux systems, install the native desktop prerequisites before the first Rust release build:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  build-essential pkg-config \
+  libglib2.0-dev libgtk-3-dev \
+  libsoup-3.0-dev \
+  libjavascriptcoregtk-4.1-dev \
+  libwebkit2gtk-4.1-dev
+```
+
+This prepares the native GTK/WebKit dependencies used by the desktop/Tauri crates in this workspace.
+
 ```bash
 git clone https://github.com/ruvnet/RuView.git
 cd RuView/rust-port/wifi-densepose-rs
@@ -1581,6 +1595,28 @@ Ensure Rust 1.75+ is installed (1.85+ recommended):
 rustup update stable
 rustc --version
 ```
+
+### Build: Linux native desktop prerequisites
+
+If you are compiling the Rust workspace on a Debian/Ubuntu-based Linux system, install the native desktop development packages first:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  build-essential pkg-config \
+  libglib2.0-dev libgtk-3-dev \
+  libsoup-3.0-dev \
+  libjavascriptcoregtk-4.1-dev \
+  libwebkit2gtk-4.1-dev
+```
+
+Then rerun:
+
+```bash
+cargo build --release
+```
+
+This is the same Linux pre-step referenced in the Rust source build section and covers the common GTK/WebKit `pkg-config` requirements used by the desktop build.
 
 ### Windows: RSSI mode shows no data
 

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/Cargo.toml
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/Cargo.toml
@@ -25,6 +25,7 @@ axum = { workspace = true }
 tower-http = { version = "0.5", features = ["fs", "cors", "set-header"] }
 tokio = { workspace = true, features = ["full", "process"] }
 futures-util = "0.3"
+ruvector-mincut = { workspace = true }
 
 # Serialization
 serde = { workspace = true }

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/lib.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/lib.rs
@@ -8,8 +8,10 @@ pub mod vital_signs;
 pub mod rvf_container;
 pub mod rvf_pipeline;
 pub mod graph_transformer;
+#[allow(dead_code)]
 pub mod trainer;
 pub mod dataset;
 pub mod sona;
 pub mod sparse_inference;
+#[allow(dead_code)]
 pub mod embedding;

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/src/main.rs
@@ -7,6 +7,7 @@
 //! - Serves the static UI files (port 8080)
 //!
 //! Replaces both ws_server.py and the Python HTTP server.
+#![allow(dead_code)]
 
 mod adaptive_classifier;
 pub mod cli;
@@ -1658,9 +1659,11 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
 
         // Populate persons from the sensing update (Kalman-smoothed via tracker).
         let raw_persons = derive_pose_from_sensing(&update);
+        let mut last_tracker_instant = s.last_tracker_instant.take();
         let tracked = tracker_bridge::tracker_update(
-            &mut s.pose_tracker, &mut s.last_tracker_instant, raw_persons,
+            &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
         );
+        s.last_tracker_instant = last_tracker_instant;
         if !tracked.is_empty() {
             update.persons = Some(tracked);
         }
@@ -1794,9 +1797,11 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
     };
 
     let raw_persons = derive_pose_from_sensing(&update);
+    let mut last_tracker_instant = s.last_tracker_instant.take();
     let tracked = tracker_bridge::tracker_update(
-        &mut s.pose_tracker, &mut s.last_tracker_instant, raw_persons,
+        &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
     );
+    s.last_tracker_instant = last_tracker_instant;
     if !tracked.is_empty() {
         update.persons = Some(tracked);
     }
@@ -3214,7 +3219,7 @@ async fn adaptive_status(State(state): State<SharedState>) -> Json<serde_json::V
             "trained_frames": model.trained_frames,
             "accuracy": model.training_accuracy,
             "version": model.version,
-            "classes": adaptive_classifier::CLASSES,
+            "classes": model.class_names,
             "class_stats": model.class_stats,
         })),
         None => Json(serde_json::json!({
@@ -3600,9 +3605,9 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     };
 
                     // Feed field model calibration if active (use per-node history for ESP32).
-                    if let Some(ref mut fm) = s.field_model {
-                        if let Some(ns) = s.node_states.get(&node_id) {
-                            field_bridge::maybe_feed_calibration(fm, &ns.frame_history);
+                    if let Some(frame_history) = s.node_states.get(&node_id).map(|ns| ns.frame_history.clone()) {
+                        if let Some(ref mut fm) = s.field_model {
+                            field_bridge::maybe_feed_calibration(fm, &frame_history);
                         }
                     }
 
@@ -3685,9 +3690,11 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     };
 
                     let raw_persons = derive_pose_from_sensing(&update);
+                    let mut last_tracker_instant = s.last_tracker_instant.take();
                     let tracked = tracker_bridge::tracker_update(
-                        &mut s.pose_tracker, &mut s.last_tracker_instant, raw_persons,
+                        &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
                     );
+                    s.last_tracker_instant = last_tracker_instant;
                     if !tracked.is_empty() {
                         update.persons = Some(tracked);
                     }
@@ -3848,9 +3855,9 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     };
 
                     // Feed field model calibration if active (use per-node history for ESP32).
-                    if let Some(ref mut fm) = s.field_model {
-                        if let Some(ns) = s.node_states.get(&node_id) {
-                            field_bridge::maybe_feed_calibration(fm, &ns.frame_history);
+                    if let Some(frame_history) = s.node_states.get(&node_id).map(|ns| ns.frame_history.clone()) {
+                        if let Some(ref mut fm) = s.field_model {
+                            field_bridge::maybe_feed_calibration(fm, &frame_history);
                         }
                     }
 
@@ -3895,9 +3902,11 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     };
 
                     let raw_persons = derive_pose_from_sensing(&update);
+                    let mut last_tracker_instant = s.last_tracker_instant.take();
                     let tracked = tracker_bridge::tracker_update(
-                        &mut s.pose_tracker, &mut s.last_tracker_instant, raw_persons,
+                        &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
                     );
+                    s.last_tracker_instant = last_tracker_instant;
                     if !tracked.is_empty() {
                         update.persons = Some(tracked);
                     }
@@ -4031,9 +4040,11 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
 
         // Populate persons from the sensing update (Kalman-smoothed via tracker).
         let raw_persons = derive_pose_from_sensing(&update);
+        let mut last_tracker_instant = s.last_tracker_instant.take();
         let tracked = tracker_bridge::tracker_update(
-            &mut s.pose_tracker, &mut s.last_tracker_instant, raw_persons,
+            &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
         );
+        s.last_tracker_instant = last_tracker_instant;
         if !tracked.is_empty() {
             update.persons = Some(tracked);
         }


### PR DESCRIPTION
## Summary

This PR fixes the Rust release build failure documented in `docs/user-guide.md` when running `cargo build --release` inside WSL, and updates the guide to document the Linux desktop prerequisites required for the Rust source build.

## Changes

- add the missing `ruvector-mincut` dependency to `wifi-densepose-sensing-server`
- fix multiple borrow-checker conflicts around tracker updates and field model calibration
- replace the stale adaptive classifier class reference with runtime model class names
- add a targeted `dead_code` compatibility workaround to avoid a `rustc` ICE observed in WSL builds
- update `docs/user-guide.md` with the Linux desktop prerequisite packages required by the desktop/Tauri build
- add a matching troubleshooting entry so the setup and recovery steps stay aligned

## Verification

- reproduced the failure in WSL
- ran `cargo build --release` in `rust-port/wifi-densepose-rs`
- confirmed the build now completes successfully
- reviewed the updated guide to ensure the prerequisite command and troubleshooting section are context-consistent

## Notes

- the remaining warnings are non-blocking and were not expanded in scope in this fix
- the documentation now includes the confirmed Linux desktop dependency packages needed for the documented build path
- this PR remains focused on restoring the documented release build path with minimal behavior changes
