### PR TITLE
fix/docker: pass args directly to binary instead of shell

### DIFF
--- a/docker/Dockerfile.rust
+++ b/docker/Dockerfile.rust
@@ -50,7 +50,12 @@ ENV RUST_LOG=info
 # Override at runtime:  docker run -e CSI_SOURCE=esp32 ...
 ENV CSI_SOURCE=auto
 
-ENTRYPOINT ["/bin/sh", "-c"]
-# Shell-form CMD allows $CSI_SOURCE to be substituted at container start.
-# The ENV default above (CSI_SOURCE=auto) applies when the variable is unset.
-CMD ["/app/sensing-server --source ${CSI_SOURCE} --tick-ms 100 --ui-path /app/ui --http-port 3000 --ws-port 3001"]
+ENTRYPOINT ["/app/sensing-server"]
+# Exec-form CMD allows arguments after the image name to reach the binary directly.
+# Use -e CSI_SOURCE=... to control the data source at runtime.
+# Examples:
+#   docker run ruvnet/wifi-densepose:latest                            # auto mode (default)
+#   docker run -e CSI_SOURCE=simulated ruvnet/wifi-densepose:latest  # synthetic data
+#   docker run -e CSI_SOURCE=esp32 ruvnet/wifi-densepose:latest       # real ESP32 hardware
+#   docker run ruvnet/wifi-densepose:latest --source simulated        # equivalent to above
+CMD []

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       #          wifi           — use host Wi-Fi RSSI/scan data (Windows netsh)
       #          simulated      — generate synthetic CSI data (no hardware required)
       - CSI_SOURCE=${CSI_SOURCE:-auto}
-    # command is passed as arguments to ENTRYPOINT (/bin/sh -c), so $CSI_SOURCE is expanded by the shell.
-    command: ["/app/sensing-server --source ${CSI_SOURCE:-auto} --tick-ms 100 --ui-path /app/ui --http-port 3000 --ws-port 3001"]
+    # command args are passed directly to the binary; CSI_SOURCE env var is read by the server.
+    command: ["/app/sensing-server", "--source", "${CSI_SOURCE:-auto}", "--tick-ms", "100", "--ui-path", "/app/ui", "--http-port", "3000", "--ws-port", "3001"]
 
   python-sensing:
     build:


### PR DESCRIPTION
## Problem

Docker run arguments (e.g. `--source wifi`) don't reach the `sensing-server` binary on Windows (and sometimes Linux). Users see:

- **PowerShell**: `wifi: 1: --source: not found` — PowerShell interprets `--` as a parameter prefix
- **Linux sh**: `/bin/sh: 0: Illegal option --` — Docker dispatches `--args` to `/bin/sh -c` which chokes on `--`

## Root Cause

The `Dockerfile.rust` uses shell-form ENTRYPOINT:

```dockerfile
ENTRYPOINT ["/bin/sh", "-c"]
CMD ["/app/sensing-server --source ${CSI_SOURCE} --tick-ms 100 ..."]
```

With `/bin/sh -c`, the entire CMD becomes a shell command string. Any arguments after the container image name are treated as `sh` options or extra positional args to the shell — they never reach `sensing-server`.

## Fix

Switch to exec-form ENTRYPOINT so arguments pass directly to the binary:

```dockerfile
ENTRYPOINT ["/app/sensing-server"]
CMD []
```

The server already reads `CSI_SOURCE` from the environment, so `-e CSI_SOURCE=simulated` continues to work for env-based configuration. Users who prefer CLI args can now write:

```bash
docker run ruvnet/wifi-densepose:latest --source simulated
```

Also update `docker-compose.yml` command to exec-form JSON array.

## Testing

```bash
# Before fix (fails on Windows):
#   docker run ruvnet/wifi-densepose:latest --source wifi
#   wifi: 1: --source: not found

# After fix (works on all platforms):
docker run ruvnet/wifi-densepose:latest --source simulated
# → Server starts in simulated mode

docker run -e CSI_SOURCE=simulated ruvnet/wifi-densepose:latest
# → Still works (env var takes precedence in auto mode)

docker compose run sensing-server --source simulated
# → compose also passes args correctly
```

Fixes #384