### PR TITLE
fix(workspace): unblock --no-default-features build on Windows (#366, #415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Rust workspace build with `--no-default-features` on Windows** (#366, #415) —
+  `wifi-densepose-mat`, `wifi-densepose-sensing-server`, and `wifi-densepose-train`
+  all depended on `wifi-densepose-signal` with default features enabled, which
+  pulled `ndarray-linalg` → `openblas-src` → vcpkg/system-BLAS through the entire
+  workspace. `--no-default-features` at the workspace root then could not opt out
+  of BLAS, breaking `cargo build` / `cargo test` on Windows without vcpkg. All
+  three consumers now declare `wifi-densepose-signal = { ..., default-features = false }`,
+  so `cargo test --workspace --no-default-features` builds cleanly without
+  vcpkg/openblas. Validated: 1,538 tests pass, 0 fail, 8 ignored.
+- **`signal` test `test_estimate_occupancy_noise_only` failed without `eigenvalue`** —
+  The test unwrapped the `NotCalibrated` stub returned when the BLAS-backed
+  `estimate_occupancy` is compiled out. Gated with `#[cfg(feature = "eigenvalue")]`
+  so it only runs when the real implementation is available.
+
 ## [v0.6.2-esp32] — 2026-04-20
 
 Firmware release cutting ADR-081 and the Timer Svc stack fix discovered during

--- a/rust-port/wifi-densepose-rs/Cargo.lock
+++ b/rust-port/wifi-densepose-rs/Cargo.lock
@@ -7979,6 +7979,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
+ "ruvector-mincut",
  "serde",
  "serde_json",
  "tempfile",

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-mat/Cargo.toml
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-mat/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["dep:serde", "chrono/serde", "geo/use-serde"]
 [dependencies]
 # Workspace dependencies
 wifi-densepose-core = { version = "0.3.0", path = "../wifi-densepose-core" }
-wifi-densepose-signal = { version = "0.3.0", path = "../wifi-densepose-signal" }
+wifi-densepose-signal = { version = "0.3.0", path = "../wifi-densepose-signal", default-features = false }
 wifi-densepose-nn = { version = "0.3.0", path = "../wifi-densepose-nn" }
 ruvector-solver = { workspace = true, optional = true }
 ruvector-temporal-tensor = { workspace = true, optional = true }

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/Cargo.toml
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-sensing-server/Cargo.toml
@@ -44,8 +44,11 @@ clap = { workspace = true }
 # Multi-BSSID WiFi scanning pipeline (ADR-022 Phase 3)
 wifi-densepose-wifiscan = { version = "0.3.0", path = "../wifi-densepose-wifiscan" }
 
-# Signal processing with RuvSense pose tracker (accuracy sprint)
-wifi-densepose-signal = { version = "0.3.0", path = "../wifi-densepose-signal" }
+# Signal processing with RuvSense pose tracker (accuracy sprint).
+# default-features = false drops the optional ndarray-linalg/BLAS chain so that
+# `--no-default-features` at the workspace root can produce a Windows-friendly
+# build without vcpkg/openblas (issue #366, #415).
+wifi-densepose-signal = { version = "0.3.0", path = "../wifi-densepose-signal", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-signal/src/ruvsense/field_model.rs
@@ -1232,6 +1232,9 @@ mod tests {
         }
     }
 
+    // estimate_occupancy() falls back to a NotCalibrated stub without the
+    // `eigenvalue` feature, so this test only makes sense with BLAS enabled.
+    #[cfg(feature = "eigenvalue")]
     #[test]
     fn test_estimate_occupancy_noise_only() {
         let config = FieldModelConfig {

--- a/rust-port/wifi-densepose-rs/crates/wifi-densepose-train/Cargo.toml
+++ b/rust-port/wifi-densepose-rs/crates/wifi-densepose-train/Cargo.toml
@@ -27,7 +27,7 @@ cuda = ["tch-backend"]
 
 [dependencies]
 # Internal crates
-wifi-densepose-signal = { version = "0.3.0", path = "../wifi-densepose-signal" }
+wifi-densepose-signal = { version = "0.3.0", path = "../wifi-densepose-signal", default-features = false }
 wifi-densepose-nn = { version = "0.3.0", path = "../wifi-densepose-nn" }
 
 # Core


### PR DESCRIPTION
## Summary

Fixes #366 and the active half of #415: `cargo build --workspace --no-default-features` and `cargo test --workspace --no-default-features` now succeed on Windows without vcpkg/openblas.

## Root cause

`wifi-densepose-mat`, `wifi-densepose-sensing-server`, and `wifi-densepose-train` all depended on `wifi-densepose-signal` **with default features enabled**, which means signal's `default = [\"eigenvalue\"]` pulled `ndarray-linalg` → `openblas-src` through the entire workspace. `--no-default-features` at the workspace root only applies to the *target* crate; transitive default features stay on. The CLAUDE.md-recommended Windows build path (`cargo test --workspace --no-default-features`) therefore could not actually opt out of BLAS.

## Fix

Three one-liners on the signal dependency:

```toml
wifi-densepose-signal = { version = \"0.3.0\", path = \"../wifi-densepose-signal\", default-features = false }
```

…in `mat/Cargo.toml`, `sensing-server/Cargo.toml`, `train/Cargo.toml`. Plus one stale-test fix:

```rust
// signal/src/ruvsense/field_model.rs
#[cfg(feature = \"eigenvalue\")]
#[test]
fn test_estimate_occupancy_noise_only() { ... }
```

The test was already failing on `main` under `--no-default-features` (unwrapping the `NotCalibrated` stub returned when the BLAS-backed impl is compiled out) — this gate makes the workspace test claim hold true.

## Validation

```
$ cargo check --workspace --no-default-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.87s

$ cargo test --workspace --no-default-features
… (lots of test results) …
Total: 1538 passed, 0 failed, 8 ignored
```

ESP32-S3 on COM7 was running unmodified firmware throughout and continued streaming live CSI (cb #15900, RSSI −44 dBm) before, during, and after these changes — server-side fix only, no firmware impact.

## Notes on user reports

The `E0432 unresolved import ruvector_mincut`, `E0425 CLASSES`, and 5× `E0499/E0502` borrow errors that the user reported in #366 against **v0.6.2 source code** are already fixed in different ways on `main` (ruvector-mincut is now declared, `CLASSES` was renamed to `model.class_names`, tracker_update uses the `.take()`+restore pattern). What was *not* fixed on `main` was the BLAS propagation — that's what this PR addresses.

## Test plan
- [x] `cargo check --workspace --no-default-features` succeeds on Windows
- [x] `cargo test --workspace --no-default-features` → 1,538 passed, 0 failed
- [x] ESP32-S3 on COM7 still streams CSI (unchanged firmware)
- [ ] CI: workspace tests on Linux + Windows runners
- [ ] CI: firmware build matrix unaffected (no firmware changes)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)