### PR TITLE
fix(ci): use env scope for secrets in gating if: expressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,26 +310,27 @@ jobs:
     runs-on: ubuntu-latest
     needs: [code-quality, test, rust-tests, performance-test, docker-build, docs]
     if: always()
+    # GitHub Actions does not allow `secrets.X` directly in step-level `if:`
+    # expressions — only `env.X`. Promote the secret to env at job scope so
+    # the gating expression below is parseable.
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
     - name: Notify Slack on success
-      if: ${{ secrets.SLACK_WEBHOOK_URL != '' && needs.code-quality.result == 'success' && needs.test.result == 'success' && needs.docker-build.result == 'success' }}
+      if: ${{ env.SLACK_WEBHOOK_URL != '' && needs.code-quality.result == 'success' && needs.test.result == 'success' && needs.docker-build.result == 'success' }}
       uses: 8398a7/action-slack@v3
       with:
         status: success
         channel: '#ci-cd'
         text: '✅ CI pipeline completed successfully for ${{ github.ref }}'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     - name: Notify Slack on failure
-      if: ${{ secrets.SLACK_WEBHOOK_URL != '' && (needs.code-quality.result == 'failure' || needs.test.result == 'failure' || needs.docker-build.result == 'failure') }}
+      if: ${{ env.SLACK_WEBHOOK_URL != '' && (needs.code-quality.result == 'failure' || needs.test.result == 'failure' || needs.docker-build.result == 'failure') }}
       uses: 8398a7/action-slack@v3
       with:
         status: failure
         channel: '#ci-cd'
         text: '❌ CI pipeline failed for ${{ github.ref }}'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     - name: Create GitHub Release
       if: github.ref == 'refs/heads/main' && needs.docker-build.result == 'success'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -377,6 +377,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [sast, dependency-scan, container-scan, iac-scan, secret-scan, license-scan, compliance-check]
     if: always()
+    # Promote secret to env-scope so the gating `if:` on the Slack-notify
+    # step below is parseable (GitHub Actions rejects `secrets.X` in
+    # step-level `if:` expressions).
+    env:
+      SECURITY_SLACK_WEBHOOK_URL: ${{ secrets.SECURITY_SLACK_WEBHOOK_URL }}
     steps:
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -402,8 +407,11 @@ jobs:
         name: security-summary
         path: security-summary.md
 
+    # GitHub Actions does not allow `secrets.X` in step-level `if:` —
+    # use env.X instead. Inherits SECURITY_SLACK_WEBHOOK_URL from the
+    # job-level env block (added below).
     - name: Notify security team on critical findings
-      if: ${{ secrets.SECURITY_SLACK_WEBHOOK_URL != '' && (needs.sast.result == 'failure' || needs.dependency-scan.result == 'failure' || needs.container-scan.result == 'failure') }}
+      if: ${{ env.SECURITY_SLACK_WEBHOOK_URL != '' && (needs.sast.result == 'failure' || needs.dependency-scan.result == 'failure' || needs.container-scan.result == 'failure') }}
       uses: 8398a7/action-slack@v3
       with:
         status: failure
@@ -415,7 +423,7 @@ jobs:
           Workflow: ${{ github.workflow }}
           Please review the security scan results immediately.
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SECURITY_SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ env.SECURITY_SLACK_WEBHOOK_URL }}
 
     - name: Create security issue on critical findings
       if: needs.sast.result == 'failure' || needs.dependency-scan.result == 'failure'


### PR DESCRIPTION
## Root cause

Every push to main has produced a 0-second CI failure with **0 jobs executed** — visible on PR #389, #377, #405, #425, #426, #427, #430, and every commit since. The workflow appeared to fail without ever running anything.

Confirmed via direct API dispatch:

\`\`\`
$ gh api -X POST repos/ruvnet/RuView/actions/workflows/167079093/dispatches -f ref=main
422 Invalid Argument - failed to parse workflow:
  (Line: 315, Col: 11): Unrecognized named-value: 'secrets'.
  Located at position 1 within expression: secrets.SLACK_WEBHOOK_URL != ''
\`\`\`

The Slack-notify steps in \`ci.yml\` (lines 315/325) and \`security-scan.yml\` (line 406) used \`\${{ secrets.X != '' }}\` directly in step-level \`if:\` conditions. **GitHub Actions does not allow direct \`secrets.X\` access in \`if:\` expressions** — only \`env.X\` is valid in that context. The whole workflow file was rejected during parse, every job was skipped, and a "failure" status was reported with no logs.

## Fix

Promote the secret to job-level \`env:\` so step-level \`if:\` references \`env.X\`. The actual secret value still flows through unchanged at runtime.

Before:
\`\`\`yaml
notify:
  steps:
  - name: Notify Slack on success
    if: \${{ secrets.SLACK_WEBHOOK_URL != '' && needs.foo.result == 'success' }}
    env:
      SLACK_WEBHOOK_URL: \${{ secrets.SLACK_WEBHOOK_URL }}
\`\`\`

After:
\`\`\`yaml
notify:
  env:
    SLACK_WEBHOOK_URL: \${{ secrets.SLACK_WEBHOOK_URL }}
  steps:
  - name: Notify Slack on success
    if: \${{ env.SLACK_WEBHOOK_URL != '' && needs.foo.result == 'success' }}
\`\`\`

Same pattern applied to \`security-scan.yml\` for \`SECURITY_SLACK_WEBHOOK_URL\`.

## Validation

\`\`\`
$ gh api -X POST repos/ruvnet/RuView/actions/workflows/167079093/dispatches -f ref=fix/ci-workflows-secrets-in-if
(no error — workflow now parses)

$ gh run list --workflow ci.yml --branch fix/ci-workflows-secrets-in-if
[{"name":"Continuous Integration","status":"in_progress","event":"workflow_dispatch"}]
\`\`\`

Pre-fix: \`name: ".github/workflows/ci.yml"\` (path — GitHub's fallback when the YAML name field can't be read), \`status: completed\` with 0 jobs in 0s.

Post-fix: \`name: "Continuous Integration"\` (matches the YAML \`name:\` field at line 1), \`status: in_progress\`, jobs actually executing.

## What this PR does NOT fix

The CI runs may still fail for **real** reasons once they actually execute (missing CI dependencies, broken tests, missing secrets, etc.). This PR only restores honesty: failures will now produce real logs you can read, instead of vanishing into a 0-second startup error.

If \`SLACK_WEBHOOK_URL\` / \`SECURITY_SLACK_WEBHOOK_URL\` aren't configured as repo secrets, the corresponding notify steps will skip gracefully (\`env.X == ''\`), which is the intended behavior.

## Test plan
- [x] \`gh api workflow dispatch\` no longer returns 422
- [x] Manually-dispatched run reaches \`in_progress\` status with name "Continuous Integration"
- [ ] Real PR-driven runs against this branch reach completion (passing or failing) with actual logs
- [ ] Confirm \`security-scan.yml\` parses on next \`schedule\` trigger or manual dispatch

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)