### PR TITLE
fix(ci): wasm-pack PATH + Dockerfile workspace stub

### DIFF
--- a/.github/workflows/dashboard-a11y.yml
+++ b/.github/workflows/dashboard-a11y.yml
@@ -24,7 +24,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: wasm32-unknown-unknown }
 
-      - run: cargo install wasm-pack --locked --version 0.13.x || true
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build nvsim WASM
         working-directory: v2

--- a/.github/workflows/dashboard-pages.yml
+++ b/.github/workflows/dashboard-pages.yml
@@ -43,7 +43,9 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-nvsim-
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked --version 0.13.x || true
+        run: |
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          which wasm-pack
 
       - name: Build nvsim WASM
         working-directory: v2

--- a/v2/crates/nvsim-server/Dockerfile
+++ b/v2/crates/nvsim-server/Dockerfile
@@ -1,17 +1,10 @@
 # Multi-stage Dockerfile for nvsim-server (ADR-092 §6.2).
 #
-# Build:
-#   docker build -f v2/crates/nvsim-server/Dockerfile -t nvsim-server:latest v2
+# Build (from v2/ as context):
+#   docker build -f crates/nvsim-server/Dockerfile -t nvsim-server:latest v2
 #
-# Run (LAN):
+# Run:
 #   docker run --rm -p 7878:7878 nvsim-server:latest
-#
-# Run with custom CORS origin:
-#   docker run --rm -p 7878:7878 nvsim-server:latest \
-#     nvsim-server --listen 0.0.0.0:7878 --allowed-origin https://example.com
-#
-# Health check:
-#   curl http://localhost:7878/api/health
 
 FROM rust:1.81-slim-bookworm AS builder
 WORKDIR /build
@@ -19,25 +12,39 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Cache deps separately from source.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/nvsim/Cargo.toml crates/nvsim/Cargo.toml
-COPY crates/nvsim-server/Cargo.toml crates/nvsim-server/Cargo.toml
-RUN mkdir -p crates/nvsim/src crates/nvsim-server/src \
-    && echo "fn main(){}" > crates/nvsim-server/src/main.rs \
-    && echo "" > crates/nvsim/src/lib.rs
-
-# This will fail because the workspace Cargo.toml references many other
-# crates. Strategy: build only nvsim + nvsim-server with --bin filter.
+# Copy a stub workspace Cargo.toml + Cargo.lock that only references
+# nvsim and nvsim-server. This dodges the full RuView workspace's
+# wifi-densepose-* deps, none of which nvsim-server uses.
+COPY Cargo.lock Cargo.lock
 COPY crates/nvsim crates/nvsim
 COPY crates/nvsim-server crates/nvsim-server
 
-# Build the binary statically against the workspace using a slimmed
-# manifest (the Cargo.lock + the two crate Cargo.tomls are enough).
-RUN cargo build --release -p nvsim-server --bin nvsim-server 2>&1 \
-    || (echo "Cargo build failed — falling back to in-crate build" \
-        && cd crates/nvsim-server \
-        && cargo build --release --bin nvsim-server)
+RUN cat <<'EOF' > Cargo.toml
+[workspace]
+resolver = "2"
+members = ["crates/nvsim", "crates/nvsim-server"]
+
+[workspace.package]
+version = "0.3.0"
+edition = "2021"
+authors = ["rUv <ruv@ruv.net>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/ruvnet/RuView"
+
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = { version = "0.10", default-features = false }
+thiserror = "1.0"
+tracing = "0.1"
+tokio = { version = "1.35", features = ["full"] }
+axum = { version = "0.7", features = ["ws", "macros"] }
+tower = { version = "0.4", features = ["full"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "compression-gzip"] }
+criterion = "0.5"
+EOF
+
+RUN cargo build --release -p nvsim-server --bin nvsim-server
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -45,7 +52,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r nvsim && useradd -r -g nvsim nvsim
 
-# Copy the binary from whichever build path succeeded.
 COPY --from=builder /build/target/release/nvsim-server /usr/local/bin/nvsim-server
 RUN chmod +x /usr/local/bin/nvsim-server
 


### PR DESCRIPTION
Closes the two post-#436 CI failures (wasm-pack PATH on Pages workflow, Dockerfile cargo resolution).