### PR TITLE
security: pin GitHub Actions to SHAs and bump vulnerable npm deps (#442)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Keep all third-party GitHub Actions on verified, pinned commit SHAs.
+  # Pairs with the SHA pinning in security-scan.yml and ci.yml so that
+  # future bumps stay automated and reviewable rather than drifting back
+  # to mutable @master / @main refs. See issue #442.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+
+  # Mobile app npm deps. Includes the @xmldom/xmldom, node-forge, and
+  # picomatch advisories from #442 plus axios and any future surface.
+  - package-ecosystem: npm
+    directory: /ui/mobile
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - mobile

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,36 @@ updates:
     labels:
       - dependencies
       - mobile
+
+  # Desktop UI npm deps. Direct vite devDep currently has a HIGH advisory
+  # (dev-server-only path traversal); track future bumps automatically.
+  - package-ecosystem: npm
+    directory: /v2/crates/wifi-densepose-desktop/ui
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - desktop
+
+  # Python deps used by v1/ and the FastAPI service. requirements.txt is
+  # only loosely pinned; let Dependabot surface upstream CVE bumps.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+
+  # Rust workspace (15+ crates). cargo audit is not currently wired into
+  # any workflow, so Dependabot is the primary automated bump path.
+  - package-ecosystem: cargo
+    directory: /v2
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
         docker stop test-container
 
     - name: Run container security scan
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
         format: 'sarif'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -111,7 +111,7 @@ jobs:
       continue-on-error: true
 
     - name: Run Snyk vulnerability scan
-      uses: snyk/actions/python@master
+      uses: snyk/actions/python@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
@@ -163,7 +163,7 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: 'wifi-densepose:scan'
         format: 'sarif'
@@ -221,7 +221,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run Checkov IaC scan
-      uses: bridgecrewio/checkov-action@master
+      uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
       with:
         directory: .
         framework: kubernetes,dockerfile,terraform,ansible
@@ -238,7 +238,7 @@ jobs:
         category: checkov
 
     - name: Run Terrascan IaC scan
-      uses: tenable/terrascan-action@main
+      uses: tenable/terrascan-action@3a6e87da8e244513bd77b631e624552643f794c6 # v1.4.1
       with:
         iac_type: 'k8s'
         iac_version: 'v1'
@@ -247,7 +247,7 @@ jobs:
         sarif_upload: true
 
     - name: Run KICS IaC scan
-      uses: checkmarx/kics-github-action@master
+      uses: checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # v2.1.20
       with:
         path: '.'
         output_path: kics-results
@@ -277,7 +277,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run TruffleHog secret scan
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
       with:
         path: ./
         base: main

--- a/ui/mobile/package-lock.json
+++ b/ui/mobile/package-lock.json
@@ -5127,9 +5127,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5308,18 +5308,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/arg": {
@@ -11935,18 +11923,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -13389,18 +13365,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -13594,9 +13558,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -14056,12 +14020,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"

--- a/ui/mobile/package.json
+++ b/ui/mobile/package.json
@@ -49,5 +49,10 @@
     "react-native-worklets": "^0.7.4",
     "typescript": "~5.9.2"
   },
+  "overrides": {
+    "@xmldom/xmldom": "0.8.13",
+    "node-forge": "^1.4.0",
+    "picomatch": "^2.3.2"
+  },
   "private": true
 }


### PR DESCRIPTION
## Summary

Addresses confirmed findings from [#442](https://github.com/ruvnet/RuView/issues/442) (Pentesterra/DevGuard report) and adds Dependabot coverage so the pins don't rot.

- Pin all third-party GitHub Actions in `security-scan.yml` and `ci.yml` to verified commit SHAs (Checkmarx KICS, Snyk, Trivy x2, Checkov, Terrascan, TruffleHog).
- Add `npm overrides` for the three flagged packages and regenerate `ui/mobile/package-lock.json`.
- Add `.github/dependabot.yml` covering **all five** package ecosystems in the repo (github-actions, mobile npm, desktop UI npm, pip, cargo) so weekly bumps stay automated and pins don't drift back to mutable / vulnerable versions.

## Files changed (5)

| File | Why |
|------|-----|
| `.github/workflows/security-scan.yml` | 6 actions SHA-pinned (was @master/@main) |
| `.github/workflows/ci.yml` | trivy-action SHA-pinned |
| `ui/mobile/package.json` | added `overrides` block |
| `ui/mobile/package-lock.json` | regenerated to apply the overrides |
| `.github/dependabot.yml` | weekly bumps for github-actions, mobile npm, desktop UI npm, pip, cargo |

## Commits (3)

1. `security: pin GitHub Actions to SHAs and bump vulnerable npm deps (#442)` — the corrective fix.
2. `chore: add Dependabot config for github-actions and ui/mobile npm (#442)` — initial regression-prevention companion.
3. `chore(dependabot): expand to pip, cargo, and desktop UI npm (#442)` — broaden coverage to the remaining ecosystems in the repo.

## Scope vs the original report

`#442` named only `checkmarx/kics-github-action@master` as the supply-chain risk. While verifying it, **5 more actions in the same workflow** had the same anti-pattern, including `snyk/actions/python@master` which has direct access to `SNYK_TOKEN` — a higher-value target. All 7 are pinned in this PR (one of them in `ci.yml` so it's the same `@master` value as `security-scan.yml:166`).

| Finding (#442) | Status |
|----------------|--------|
| `checkmarx/kics-github-action@master` (CRITICAL) | ✅ pinned to v2.1.20 |
| `@xmldom/xmldom@0.8.11` (3 advisories) | ✅ overridden to 0.8.13 |
| `node-forge@1.3.3` (3 HIGH advisories) | ✅ overridden to ^1.4.0 |
| `picomatch@2.3.1` (1 HIGH, dev tooling only) | ✅ overridden to ^2.3.2 |
| `CVE-2022-29217` ECDSA malleability | ❌ false positive — PyJWT is not in this repo |

The `dashboard/package-lock.json` path the report referenced did not exist when the report was filed; actual location was `ui/mobile/package-lock.json`. (A `dashboard/` directory has since been added on `main` for separate work.)

## Dependabot scope (all five ecosystems)

| Ecosystem | Directory | Why included |
|-----------|-----------|-------------|
| `github-actions` | `/` | Pairs with the SHA pinning above; without it, pins rot back to mutable refs over time. |
| `npm` | `/ui/mobile` | Same package surface that produced the xmldom / node-forge / picomatch advisories. |
| `npm` | `/v2/crates/wifi-densepose-desktop/ui` | Direct devDep `vite@<=6.4.1` currently has a HIGH advisory (dev-server-only path traversal). |
| `pip` | `/` | `requirements.txt` is loosely pinned; `python-jose`, `passlib`, FastAPI stack all have CVE flow. |
| `cargo` | `/v2` | 15+ Rust crates; `cargo audit` is not wired into any CI workflow yet, so Dependabot is the primary automated path. |

Per-ecosystem `open-pull-requests-limit` caps the noise; labels (`mobile`, `desktop`, `python`, `rust`, `github-actions`) route PRs distinctly.

## Out of scope (tracked separately)

- **#443** — sensing-server unauth REST API surface; pending design-intent confirmation from @ruvnet before any code change lands.
- **Bearer-token-shaped string in git history** — confirmed test seed (development), no rotation required per repo owner.
- `axios` / `lodash` / `vite` advisories surfaced by the parallel deep-audit pass — these will be picked up by Dependabot once it's enabled (or can be done in fast-follow PRs).

## Verification

```bash
# 1) No mutable refs left:
$ grep -rE 'uses:.*@(main|master|latest)$' .github/workflows/
(no output)

# 2) Lockfile reflects overrides:
@xmldom/xmldom => 0.8.13
node-forge     => 1.4.0
picomatch      => 2.3.2

# 3) npm audit improvement:
# Before: 25 advisories (5 HIGH, 16 moderate, 4 low)
# After:  22 advisories (2 HIGH, 16 moderate, 4 low)   ← 3 HIGH removed = the 3 node-forge CVEs
```

## Operational follow-up (not a code change)

- Rotate `SNYK_TOKEN` and `SEMGREP_APP_TOKEN` since they were exposed to a job using `@master`-pinned actions during the public TeamPCP compromise window. Rotation is a secrets-store operation.

## Test plan

- [ ] CI pipeline green on the PR (Trivy, Checkov, KICS, Terrascan, TruffleHog, Snyk all run with new SHA pins).
- [ ] `npm audit` confirms drop to 22 advisories on `ui/mobile`.
- [ ] Mobile app build (`expo prebuild` / EAS) still succeeds locally.
- [ ] After merge: Dependabot UI shows all 5 configured ecosystems active.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)