### PR TITLE
fix(sensing): reduce empty-room adaptive false positives

### DIFF
--- a/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/adaptive_classifier.rs
@@ -16,61 +16,164 @@
 //! with the appropriate filename convention.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 
 // ── Feature vector ───────────────────────────────────────────────────────────
 
 /// Extended feature vector: 7 server features + 8 subcarrier-derived features = 15.
-const N_FEATURES: usize = 15;
+pub const N_FEATURES: usize = 15;
+
+/// Temporal classifier window size. The calibration bursts showed that roughly
+/// 4-second windows separate absent/moving much better than single frames.
+pub const TEMPORAL_WINDOW_SIZE: usize = 512;
+pub const N_TEMPORAL_FEATURES: usize = N_FEATURES * 6;
 
 /// Default class names for backward compatibility with old saved models.
 const DEFAULT_CLASSES: &[&str] = &["absent", "present_still", "present_moving", "active"];
 
 /// Extract extended feature vector from a JSONL frame (features + raw amplitudes).
 pub fn features_from_frame(frame: &serde_json::Value) -> [f64; N_FEATURES] {
-    let feat = frame.get("features").cloned().unwrap_or(serde_json::Value::Null);
+    let feat = frame
+        .get("features")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
     let nodes = frame.get("nodes").and_then(|n| n.as_array());
     let amps: Vec<f64> = nodes
         .and_then(|ns| ns.first())
         .and_then(|n| n.get("amplitude"))
         .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().filter_map(|v| v.as_f64()).collect())
+        .map(|arr| values_to_f64_vec(arr))
         .unwrap_or_default();
 
+    features_from_json_and_amplitudes(&feat, &amps)
+}
+
+fn features_from_node_frame(
+    frame: &serde_json::Value,
+    node_feature: &serde_json::Value,
+) -> [f64; N_FEATURES] {
+    let node_id = node_feature.get("node_id").and_then(|v| v.as_u64());
+    let feat = node_feature
+        .get("features")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let amps = frame
+        .get("nodes")
+        .and_then(|n| n.as_array())
+        .and_then(|nodes| {
+            nodes.iter().find(|node| {
+                node_id.is_some_and(|id| node.get("node_id").and_then(|v| v.as_u64()) == Some(id))
+            })
+        })
+        .and_then(|node| node.get("amplitude"))
+        .and_then(|a| a.as_array())
+        .map(|arr| values_to_f64_vec(arr))
+        .unwrap_or_default();
+
+    features_from_json_and_amplitudes(&feat, &amps)
+}
+
+fn values_to_f64_vec(values: &[serde_json::Value]) -> Vec<f64> {
+    values.iter().filter_map(|v| v.as_f64()).collect()
+}
+
+fn features_from_json_and_amplitudes(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_FEATURES] {
     // Server-computed features (0-6).
     let variance = feat.get("variance").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let mbp = feat.get("motion_band_power").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let bbp = feat.get("breathing_band_power").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let sp = feat.get("spectral_power").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let df = feat.get("dominant_freq_hz").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let cp = feat.get("change_points").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let rssi = feat.get("mean_rssi").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let mbp = feat
+        .get("motion_band_power")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let bbp = feat
+        .get("breathing_band_power")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let sp = feat
+        .get("spectral_power")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let df = feat
+        .get("dominant_freq_hz")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let cp = feat
+        .get("change_points")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let rssi = feat
+        .get("mean_rssi")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
 
     // Subcarrier-derived features (7-14).
     let (amp_mean, amp_std, amp_skew, amp_kurt, amp_iqr, amp_entropy, amp_max, amp_range) =
-        subcarrier_stats(&amps);
+        subcarrier_stats(amps);
 
     [
-        variance, mbp, bbp, sp, df, cp, rssi,
-        amp_mean, amp_std, amp_skew, amp_kurt, amp_iqr, amp_entropy, amp_max, amp_range,
+        variance,
+        mbp,
+        bbp,
+        sp,
+        df,
+        cp,
+        rssi,
+        amp_mean,
+        amp_std,
+        amp_skew,
+        amp_kurt,
+        amp_iqr,
+        amp_entropy,
+        amp_max,
+        amp_range,
     ]
 }
 
 /// Also keep a simpler version for runtime (no JSONL, just FeatureInfo + amps).
 pub fn features_from_runtime(feat: &serde_json::Value, amps: &[f64]) -> [f64; N_FEATURES] {
     let variance = feat.get("variance").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let mbp = feat.get("motion_band_power").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let bbp = feat.get("breathing_band_power").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let sp = feat.get("spectral_power").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let df = feat.get("dominant_freq_hz").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let cp = feat.get("change_points").and_then(|v| v.as_f64()).unwrap_or(0.0);
-    let rssi = feat.get("mean_rssi").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let mbp = feat
+        .get("motion_band_power")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let bbp = feat
+        .get("breathing_band_power")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let sp = feat
+        .get("spectral_power")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let df = feat
+        .get("dominant_freq_hz")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let cp = feat
+        .get("change_points")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let rssi = feat
+        .get("mean_rssi")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
     let (amp_mean, amp_std, amp_skew, amp_kurt, amp_iqr, amp_entropy, amp_max, amp_range) =
         subcarrier_stats(amps);
     [
-        variance, mbp, bbp, sp, df, cp, rssi,
-        amp_mean, amp_std, amp_skew, amp_kurt, amp_iqr, amp_entropy, amp_max, amp_range,
+        variance,
+        mbp,
+        bbp,
+        sp,
+        df,
+        cp,
+        rssi,
+        amp_mean,
+        amp_std,
+        amp_skew,
+        amp_kurt,
+        amp_iqr,
+        amp_entropy,
+        amp_max,
+        amp_range,
     ]
 }
 
@@ -98,12 +201,18 @@ fn subcarrier_stats(amps: &[f64]) -> (f64, f64, f64, f64, f64, f64, f64, f64) {
 
     // Spectral entropy (normalised).
     let total_power: f64 = amps.iter().map(|a| a * a).sum::<f64>().max(1e-9);
-    let entropy: f64 = amps.iter()
+    let entropy: f64 = amps
+        .iter()
         .map(|a| {
             let p = (a * a) / total_power;
-            if p > 1e-12 { -p * p.ln() } else { 0.0 }
+            if p > 1e-12 {
+                -p * p.ln()
+            } else {
+                0.0
+            }
         })
-        .sum::<f64>() / n.ln().max(1e-9); // normalise to [0,1]
+        .sum::<f64>()
+        / n.ln().max(1e-9); // normalise to [0,1]
 
     let max_val = sorted.last().copied().unwrap_or(0.0);
     let range = max_val - sorted.first().copied().unwrap_or(0.0);
@@ -119,6 +228,233 @@ pub struct ClassStats {
     pub count: usize,
     pub mean: [f64; N_FEATURES],
     pub stddev: [f64; N_FEATURES],
+}
+
+// ── Temporal window model ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemporalModel {
+    /// Number of per-frame feature vectors summarised for training/runtime.
+    pub window_size: usize,
+    /// Class names in centroid order.
+    pub class_names: Vec<String>,
+    /// Standardised temporal centroids: [n_classes x N_TEMPORAL_FEATURES].
+    pub class_centroids: Vec<Vec<f64>>,
+    /// Global temporal feature normalisation.
+    pub global_mean: Vec<f64>,
+    pub global_std: Vec<f64>,
+}
+
+impl TemporalModel {
+    #[cfg(test)]
+    fn from_centroids_for_tests(
+        window_size: usize,
+        class_names: Vec<String>,
+        class_centroids: Vec<Vec<f64>>,
+        global_mean: Vec<f64>,
+        global_std: Vec<f64>,
+    ) -> Self {
+        Self {
+            window_size,
+            class_names,
+            class_centroids,
+            global_mean,
+            global_std,
+        }
+    }
+
+    pub fn classify(&self, history: &VecDeque<[f64; N_FEATURES]>) -> Option<(String, f64)> {
+        let temporal = temporal_features_from_history(history, self.window_size)?;
+        if self.class_centroids.is_empty() {
+            return None;
+        }
+        let mut x = vec![0.0; temporal.len()];
+        for i in 0..temporal.len() {
+            let mu = self.global_mean.get(i).copied().unwrap_or(0.0);
+            let sd = self.global_std.get(i).copied().unwrap_or(1.0).max(1e-9);
+            x[i] = (temporal[i] - mu) / sd;
+        }
+
+        let distances: Vec<f64> = self
+            .class_centroids
+            .iter()
+            .map(|centroid| {
+                let d = x.len().min(centroid.len()).max(1);
+                x.iter()
+                    .zip(centroid)
+                    .take(d)
+                    .map(|(a, b)| (a - b).powi(2))
+                    .sum::<f64>()
+                    / d as f64
+            })
+            .collect();
+        let (best_idx, best_dist) = distances
+            .iter()
+            .enumerate()
+            .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))?;
+
+        // Softmax over negative average squared distance. The scale factor keeps
+        // the confidence useful for nearest-centroid distances in standardised space.
+        let scale = 0.25;
+        let max_score = distances
+            .iter()
+            .map(|d| -d / scale)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let exp_sum: f64 = distances
+            .iter()
+            .map(|d| ((-d / scale) - max_score).exp())
+            .sum();
+        let confidence = (((-*best_dist / scale) - max_score).exp() / exp_sum).clamp(0.0, 1.0);
+        let label = self
+            .class_names
+            .get(best_idx)
+            .cloned()
+            .unwrap_or_else(|| "present_still".to_string());
+        Some((label, confidence))
+    }
+}
+
+pub fn temporal_features_from_history(
+    history: &VecDeque<[f64; N_FEATURES]>,
+    window_size: usize,
+) -> Option<Vec<f64>> {
+    if history.len() < window_size || window_size == 0 {
+        return None;
+    }
+    let start = history.len() - window_size;
+    let window: Vec<&[f64; N_FEATURES]> = history.iter().skip(start).collect();
+    Some(summarize_temporal_window(&window))
+}
+
+fn summarize_temporal_window(window: &[&[f64; N_FEATURES]]) -> Vec<f64> {
+    let n = window.len().max(1) as f64;
+    let mut mean = vec![0.0; N_FEATURES];
+    let mut min_v = vec![f64::INFINITY; N_FEATURES];
+    let mut max_v = vec![f64::NEG_INFINITY; N_FEATURES];
+    for frame in window {
+        for i in 0..N_FEATURES {
+            mean[i] += frame[i];
+            min_v[i] = min_v[i].min(frame[i]);
+            max_v[i] = max_v[i].max(frame[i]);
+        }
+    }
+    for v in &mut mean {
+        *v /= n;
+    }
+
+    let mut std = vec![0.0; N_FEATURES];
+    for frame in window {
+        for i in 0..N_FEATURES {
+            std[i] += (frame[i] - mean[i]).powi(2);
+        }
+    }
+    for v in &mut std {
+        *v = (*v / n).sqrt();
+    }
+
+    let first = window.first().copied().unwrap();
+    let last = window.last().copied().unwrap();
+    let mut delta = vec![0.0; N_FEATURES];
+    for i in 0..N_FEATURES {
+        delta[i] = last[i] - first[i];
+    }
+
+    let mut mad = vec![0.0; N_FEATURES];
+    if window.len() > 1 {
+        for pair in window.windows(2) {
+            for i in 0..N_FEATURES {
+                mad[i] += (pair[1][i] - pair[0][i]).abs();
+            }
+        }
+        let denom = (window.len() - 1) as f64;
+        for v in &mut mad {
+            *v /= denom;
+        }
+    }
+
+    [mean, std, min_v, max_v, delta, mad].concat()
+}
+
+fn train_temporal_model(
+    samples: &[Sample],
+    n_classes: usize,
+    class_names: &[String],
+) -> Option<TemporalModel> {
+    let mut temporal_samples: Vec<(Vec<f64>, usize)> = Vec::new();
+    let mut by_sequence: HashMap<(usize, String), Vec<[f64; N_FEATURES]>> = HashMap::new();
+    for s in samples {
+        if s.class_idx < n_classes {
+            by_sequence
+                .entry((s.class_idx, s.sequence_key.clone()))
+                .or_default()
+                .push(s.features);
+        }
+    }
+
+    for ((class_idx, _sequence_key), frames) in by_sequence.iter() {
+        if frames.len() < TEMPORAL_WINDOW_SIZE {
+            continue;
+        }
+        for start in (0..=frames.len() - TEMPORAL_WINDOW_SIZE).step_by(TEMPORAL_WINDOW_SIZE) {
+            let window: Vec<&[f64; N_FEATURES]> =
+                frames[start..start + TEMPORAL_WINDOW_SIZE].iter().collect();
+            temporal_samples.push((summarize_temporal_window(&window), *class_idx));
+        }
+    }
+    if temporal_samples.len() < n_classes {
+        return None;
+    }
+
+    let n = temporal_samples.len();
+    let d = N_TEMPORAL_FEATURES;
+    let mut global_mean = vec![0.0; d];
+    for (x, _) in &temporal_samples {
+        for i in 0..d {
+            global_mean[i] += x[i];
+        }
+    }
+    for v in &mut global_mean {
+        *v /= n as f64;
+    }
+    let mut global_std = vec![0.0; d];
+    for (x, _) in &temporal_samples {
+        for i in 0..d {
+            global_std[i] += (x[i] - global_mean[i]).powi(2);
+        }
+    }
+    for v in &mut global_std {
+        *v = (*v / n as f64).sqrt().max(1e-9);
+    }
+
+    let mut sums = vec![vec![0.0; d]; n_classes];
+    let mut counts = vec![0usize; n_classes];
+    for (x, c) in &temporal_samples {
+        counts[*c] += 1;
+        for i in 0..d {
+            sums[*c][i] += (x[i] - global_mean[i]) / global_std[i];
+        }
+    }
+    let mut class_centroids = vec![vec![0.0; d]; n_classes];
+    for c in 0..n_classes {
+        if counts[c] == 0 {
+            continue;
+        }
+        for i in 0..d {
+            class_centroids[c][i] = sums[c][i] / counts[c] as f64;
+        }
+    }
+    eprintln!(
+        "Temporal model: {} windows across {} classes",
+        temporal_samples.len(),
+        n_classes
+    );
+    Some(TemporalModel {
+        window_size: TEMPORAL_WINDOW_SIZE,
+        class_names: class_names.to_vec(),
+        class_centroids,
+        global_mean,
+        global_std,
+    })
 }
 
 // ── Trained model ────────────────────────────────────────────────────────────
@@ -140,6 +476,9 @@ pub struct AdaptiveModel {
     /// Dynamically discovered class names (in index order).
     #[serde(default = "default_class_names")]
     pub class_names: Vec<String>,
+    /// Optional nearest-centroid temporal model over rolling feature windows.
+    #[serde(default)]
+    pub temporal_model: Option<TemporalModel>,
 }
 
 /// Backward-compatible fallback for models saved without class_names.
@@ -159,6 +498,7 @@ impl Default for AdaptiveModel {
             training_accuracy: 0.0,
             version: 1,
             class_names: default_class_names(),
+            temporal_model: None,
         }
     }
 }
@@ -197,7 +537,9 @@ impl AdaptiveModel {
         }
 
         // Pick argmax.
-        let (best_c, best_p) = probs.iter().enumerate()
+        let (best_c, best_p) = probs
+            .iter()
+            .enumerate()
             .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
             .unwrap();
         let label = if best_c < self.class_names.len() {
@@ -206,6 +548,14 @@ impl AdaptiveModel {
             "present_still".to_string()
         };
         (label, *best_p)
+    }
+
+    /// Classify a rolling temporal history if this model has temporal centroids.
+    pub fn classify_temporal(
+        &self,
+        history: &VecDeque<[f64; N_FEATURES]>,
+    ) -> Option<(String, f64)> {
+        self.temporal_model.as_ref()?.classify(history)
     }
 
     /// Save model to a JSON file.
@@ -218,8 +568,7 @@ impl AdaptiveModel {
     /// Load model from a JSON file.
     pub fn load(path: &Path) -> std::io::Result<Self> {
         let json = std::fs::read_to_string(path)?;
-        serde_json::from_str(&json)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        serde_json::from_str(&json).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
     }
 }
 
@@ -229,6 +578,10 @@ impl AdaptiveModel {
 struct Sample {
     features: [f64; N_FEATURES],
     class_idx: usize,
+    /// Stable sequence key used for temporal training windows. RuView multi-node
+    /// JSONL lines are expanded to one sample per node; temporal windows must
+    /// not mix nodes or recordings.
+    sequence_key: String,
 }
 
 /// Load JSONL recording frames and assign a class label based on filename.
@@ -237,14 +590,56 @@ fn load_recording(path: &Path, class_idx: usize) -> Vec<Sample> {
         Ok(c) => c,
         Err(_) => return Vec::new(),
     };
-    content.lines().filter_map(|line| {
-        let v: serde_json::Value = serde_json::from_str(line).ok()?;
-        // Use extended features (server features + subcarrier stats).
-        Some(Sample {
-            features: features_from_frame(&v),
-            class_idx,
+    let recording_key = path.to_string_lossy().to_string();
+    content
+        .lines()
+        .flat_map(|line| {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+                return Vec::new();
+            };
+
+            // RuView live recordings include a fused/global `features` object plus
+            // per-node `node_features`.  Training on only the fused update collapses
+            // six ESP32 viewpoints into one noisy sample and makes the adaptive
+            // model over-report movement.  Prefer one sample per fresh node so the
+            // runtime per-node temporal classifier is trained on the same schema it
+            // sees live.
+            if let Some(node_features) = v.get("node_features").and_then(|n| n.as_array()) {
+                let samples: Vec<Sample> = node_features
+                    .iter()
+                    .filter(|node_feature| {
+                        !node_feature
+                            .get("stale")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false)
+                    })
+                    .filter(|node_feature| node_feature.get("features").is_some())
+                    .map(|node_feature| {
+                        let node_id = node_feature
+                            .get("node_id")
+                            .and_then(|v| v.as_u64())
+                            .map(|id| id.to_string())
+                            .unwrap_or_else(|| "unknown".to_string());
+                        Sample {
+                            features: features_from_node_frame(&v, node_feature),
+                            class_idx,
+                            sequence_key: format!("{recording_key}::node_{node_id}"),
+                        }
+                    })
+                    .collect();
+                if !samples.is_empty() {
+                    return samples;
+                }
+            }
+
+            // Backward-compatible fallback for older single-node/fused JSONL.
+            vec![Sample {
+                features: features_from_frame(&v),
+                class_idx,
+                sequence_key: format!("{recording_key}::fused"),
+            }]
         })
-    }).collect()
+        .collect()
 }
 
 /// Map a recording filename to a class name (String).
@@ -257,13 +652,23 @@ fn classify_recording_name(name: &str) -> Option<String> {
     // or the entire middle portion if no pattern matches.
 
     // Check common patterns first for backward compat
-    if lower.contains("empty") || lower.contains("absent") { return Some("absent".into()); }
-    if lower.contains("still") || lower.contains("sitting") || lower.contains("standing") { return Some("present_still".into()); }
-    if lower.contains("walking") || lower.contains("moving") { return Some("present_moving".into()); }
-    if lower.contains("active") || lower.contains("exercise") || lower.contains("running") { return Some("active".into()); }
+    if lower.contains("empty") || lower.contains("absent") {
+        return Some("absent".into());
+    }
+    if lower.contains("still") || lower.contains("sitting") || lower.contains("standing") {
+        return Some("present_still".into());
+    }
+    if lower.contains("walking") || lower.contains("moving") {
+        return Some("present_moving".into());
+    }
+    if lower.contains("active") || lower.contains("exercise") || lower.contains("running") {
+        return Some("active".into());
+    }
 
     // Fallback: extract class from filename structure train_<class>_*.jsonl
-    let stem = lower.trim_start_matches("train_").trim_end_matches(".jsonl");
+    let stem = lower
+        .trim_start_matches("train_")
+        .trim_end_matches(".jsonl");
     let class_name = stem.split('_').next().unwrap_or(stem);
     if !class_name.is_empty() {
         Some(class_name.to_string())
@@ -318,8 +723,12 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
     for (path, fname, class_name) in &file_classes {
         let class_idx = class_map[class_name];
         let loaded = load_recording(path, class_idx);
-        eprintln!("  Loaded {}: {} frames → class '{}'",
-                 fname, loaded.len(), class_name);
+        eprintln!(
+            "  Loaded {}: {} frames → class '{}'",
+            fname,
+            loaded.len(),
+            class_name
+        );
         samples.extend(loaded);
     }
 
@@ -328,15 +737,22 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
     }
 
     let n = samples.len();
-    eprintln!("Total training samples: {n} across {n_classes} classes: {:?}", class_names);
+    eprintln!(
+        "Total training samples: {n} across {n_classes} classes: {:?}",
+        class_names
+    );
 
     // ── Compute global normalisation stats ──
     let mut global_mean = [0.0f64; N_FEATURES];
     let mut global_var = [0.0f64; N_FEATURES];
     for s in &samples {
-        for i in 0..N_FEATURES { global_mean[i] += s.features[i]; }
+        for i in 0..N_FEATURES {
+            global_mean[i] += s.features[i];
+        }
     }
-    for i in 0..N_FEATURES { global_mean[i] /= n as f64; }
+    for i in 0..N_FEATURES {
+        global_mean[i] /= n as f64;
+    }
     for s in &samples {
         for i in 0..N_FEATURES {
             global_var[i] += (s.features[i] - global_mean[i]).powi(2);
@@ -378,13 +794,16 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
     }
 
     // ── Normalise all samples ──
-    let mut norm_samples: Vec<([f64; N_FEATURES], usize)> = samples.iter().map(|s| {
-        let mut x = [0.0; N_FEATURES];
-        for i in 0..N_FEATURES {
-            x[i] = (s.features[i] - global_mean[i]) / (global_std[i] + 1e-9);
-        }
-        (x, s.class_idx)
-    }).collect();
+    let mut norm_samples: Vec<([f64; N_FEATURES], usize)> = samples
+        .iter()
+        .map(|s| {
+            let mut x = [0.0; N_FEATURES];
+            for i in 0..N_FEATURES {
+                x[i] = (s.features[i] - global_mean[i]) / (global_std[i] + 1e-9);
+            }
+            (x, s.class_idx)
+        })
+        .collect();
 
     // ── Train logistic regression via mini-batch SGD ──
     let mut weights: Vec<Vec<f64>> = vec![vec![0.0f64; N_FEATURES + 1]; n_classes];
@@ -395,7 +814,9 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
     // Shuffle helper (simple LCG for determinism).
     let mut rng_state: u64 = 42;
     let mut rng_next = move || -> u64 {
-        rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        rng_state = rng_state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         rng_state >> 33
     };
 
@@ -472,10 +893,15 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
                 logits[c] += weights[c][i] * x[i];
             }
         }
-        let pred = logits.iter().enumerate()
+        let pred = logits
+            .iter()
+            .enumerate()
             .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .unwrap().0;
-        if pred == *target { correct += 1; }
+            .unwrap()
+            .0;
+        if pred == *target {
+            correct += 1;
+        }
     }
     let accuracy = correct as f64 / n as f64;
     eprintln!("Training accuracy: {correct}/{n} = {accuracy:.1}%");
@@ -492,16 +918,28 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
                 logits[c] += weights[c][i] * x[i];
             }
         }
-        let pred = logits.iter().enumerate()
+        let pred = logits
+            .iter()
+            .enumerate()
             .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .unwrap().0;
-        if pred == *target { class_correct[*target] += 1; }
+            .unwrap()
+            .0;
+        if pred == *target {
+            class_correct[*target] += 1;
+        }
     }
     for c in 0..n_classes {
         let tot = class_total[c].max(1);
-        eprintln!("  {}: {}/{} ({:.0}%)", class_names[c], class_correct[c], tot,
-                 class_correct[c] as f64 / tot as f64 * 100.0);
+        eprintln!(
+            "  {}: {}/{} ({:.0}%)",
+            class_names[c],
+            class_correct[c],
+            tot,
+            class_correct[c] as f64 / tot as f64 * 100.0
+        );
     }
+
+    let temporal_model = train_temporal_model(&samples, n_classes, &class_names);
 
     Ok(AdaptiveModel {
         class_stats,
@@ -512,10 +950,175 @@ pub fn train_from_recordings(recordings_dir: &Path) -> Result<AdaptiveModel, Str
         training_accuracy: accuracy,
         version: 1,
         class_names,
+        temporal_model,
     })
 }
 
 /// Default path for the saved adaptive model.
 pub fn model_path() -> PathBuf {
     PathBuf::from("data/adaptive_model.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn temporal_features_summarise_mean_volatility_extremes_drift_and_change() {
+        let mut history = VecDeque::new();
+        let mut a = [0.0; N_FEATURES];
+        let mut b = [0.0; N_FEATURES];
+        let mut c = [0.0; N_FEATURES];
+        a[0] = 1.0;
+        b[0] = 3.0;
+        c[0] = 5.0;
+        history.push_back(a);
+        history.push_back(b);
+        history.push_back(c);
+
+        let temporal = temporal_features_from_history(&history, 3).expect("full window");
+
+        assert_eq!(temporal.len(), N_FEATURES * 6);
+        assert!((temporal[0] - 3.0).abs() < 1e-9, "mean feature");
+        assert!(
+            (temporal[N_FEATURES] - (8.0_f64 / 3.0).sqrt()).abs() < 1e-9,
+            "std feature"
+        );
+        assert!((temporal[N_FEATURES * 2] - 1.0).abs() < 1e-9, "min feature");
+        assert!((temporal[N_FEATURES * 3] - 5.0).abs() < 1e-9, "max feature");
+        assert!(
+            (temporal[N_FEATURES * 4] - 4.0).abs() < 1e-9,
+            "delta feature"
+        );
+        assert!(
+            (temporal[N_FEATURES * 5] - 2.0).abs() < 1e-9,
+            "mean absolute diff feature"
+        );
+    }
+
+    #[test]
+    fn temporal_model_classifies_by_nearest_standardized_centroid() {
+        let mut model = AdaptiveModel::default();
+        model.class_names = vec!["absent".into(), "present_moving".into()];
+        let mut present = vec![0.0; N_FEATURES * 6];
+        for idx in [0, N_FEATURES * 2, N_FEATURES * 3] {
+            for feature in 0..N_FEATURES {
+                present[idx + feature] = 10.0;
+            }
+        }
+        model.temporal_model = Some(TemporalModel::from_centroids_for_tests(
+            3,
+            vec!["absent".into(), "present_moving".into()],
+            vec![vec![0.0; N_FEATURES * 6], present],
+            vec![0.0; N_FEATURES * 6],
+            vec![1.0; N_FEATURES * 6],
+        ));
+
+        let mut history = VecDeque::new();
+        for _ in 0..3 {
+            history.push_back([10.0; N_FEATURES]);
+        }
+
+        let (label, confidence) = model
+            .classify_temporal(&history)
+            .expect("temporal prediction");
+
+        assert_eq!(label, "present_moving");
+        assert!(
+            confidence > 0.90,
+            "expected high confidence, got {confidence}"
+        );
+    }
+
+    #[test]
+    fn temporal_model_waits_until_minimum_window_is_available() {
+        let model = AdaptiveModel {
+            temporal_model: Some(TemporalModel::from_centroids_for_tests(
+                4,
+                vec!["absent".into()],
+                vec![vec![0.0; N_FEATURES * 6]],
+                vec![0.0; N_FEATURES * 6],
+                vec![1.0; N_FEATURES * 6],
+            )),
+            ..AdaptiveModel::default()
+        };
+        let mut history = VecDeque::new();
+        history.push_back([0.0; N_FEATURES]);
+
+        assert!(model.classify_temporal(&history).is_none());
+    }
+
+    #[test]
+    fn load_recording_expands_ruview_updates_into_per_node_samples() {
+        let path = std::env::temp_dir().join(format!(
+            "ruview_multi_node_recording_{}_{}.jsonl",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let jsonl = serde_json::json!({
+            "type": "sensing_update",
+            "nodes": [
+                {"node_id": 2, "amplitude": [1.0, 3.0, 5.0]},
+                {"node_id": 4, "amplitude": [10.0, 14.0, 18.0]}
+            ],
+            "node_features": [
+                {"node_id": 2, "features": {
+                    "mean_rssi": -54.0,
+                    "variance": 2.0,
+                    "motion_band_power": 3.0,
+                    "breathing_band_power": 4.0,
+                    "dominant_freq_hz": 0.2,
+                    "change_points": 1,
+                    "spectral_power": 5.0
+                }},
+                {"node_id": 4, "features": {
+                    "mean_rssi": -20.0,
+                    "variance": 20.0,
+                    "motion_band_power": 30.0,
+                    "breathing_band_power": 40.0,
+                    "dominant_freq_hz": 0.4,
+                    "change_points": 2,
+                    "spectral_power": 50.0
+                }}
+            ],
+            "features": {
+                "mean_rssi": -999.0,
+                "variance": 999.0,
+                "motion_band_power": 999.0,
+                "breathing_band_power": 999.0,
+                "dominant_freq_hz": 9.99,
+                "change_points": 99,
+                "spectral_power": 999.0
+            }
+        })
+        .to_string();
+        std::fs::write(&path, format!("{}\n", jsonl)).unwrap();
+
+        let samples = load_recording(&path, 7);
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(
+            samples.len(),
+            2,
+            "one training sample per node, not one global update"
+        );
+        assert_eq!(samples[0].class_idx, 7);
+        assert_eq!(samples[1].class_idx, 7);
+        assert_eq!(samples[0].features[0], 2.0);
+        assert_eq!(samples[0].features[6], -54.0);
+        assert_eq!(samples[1].features[0], 20.0);
+        assert_eq!(samples[1].features[6], -20.0);
+        assert!(
+            (samples[0].features[7] - 3.0).abs() < 1e-9,
+            "node 2 amplitude mean"
+        );
+        assert!(
+            (samples[1].features[7] - 14.0).abs() < 1e-9,
+            "node 4 amplitude mean"
+        );
+    }
 }

--- a/v2/crates/wifi-densepose-sensing-server/src/main.rs
+++ b/v2/crates/wifi-densepose-sensing-server/src/main.rs
@@ -21,11 +21,13 @@ mod tracker_bridge;
 pub mod types;
 mod vital_signs;
 
-// Training pipeline modules (exposed via lib.rs)
-use wifi_densepose_sensing_server::{graph_transformer, trainer, dataset, embedding};
+use adaptive_classifier::N_FEATURES;
 
-use std::collections::{HashMap, VecDeque};
+// Training pipeline modules (exposed via lib.rs)
+use wifi_densepose_sensing_server::{dataset, embedding, graph_transformer, trainer};
+
 use ruvector_mincut::{DynamicMinCut, MinCutBuilder};
+use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -34,8 +36,7 @@ use std::time::Duration;
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        Path,
-        State,
+        Path, State,
     },
     response::{Html, IntoResponse, Json},
     routing::{delete, get, post},
@@ -43,28 +44,26 @@ use axum::{
 };
 use clap::Parser;
 
+use axum::http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
 use tokio::sync::{broadcast, RwLock};
 use tower_http::services::ServeDir;
 use tower_http::set_header::SetResponseHeaderLayer;
-use axum::http::HeaderValue;
-use tracing::{info, warn, debug, error};
+use tracing::{debug, error, info, warn};
 
 use rvf_container::{RvfBuilder, RvfContainerInfo, RvfReader, VitalSignConfig};
 use rvf_pipeline::ProgressiveLoader;
 use vital_signs::{VitalSignDetector, VitalSigns};
 
 // ADR-022 Phase 3: Multi-BSSID pipeline integration
-use wifi_densepose_wifiscan::{
-    BssidRegistry, WindowsWifiPipeline,
-};
 use wifi_densepose_wifiscan::parse_netsh_output as parse_netsh_bssid_output;
+use wifi_densepose_wifiscan::{BssidRegistry, WindowsWifiPipeline};
 
 // Accuracy sprint: Kalman tracker, multistatic fusion, field model
+use wifi_densepose_signal::ruvsense::field_model::{CalibrationStatus, FieldModel};
+use wifi_densepose_signal::ruvsense::multistatic::{MultistaticConfig, MultistaticFuser};
 use wifi_densepose_signal::ruvsense::pose_tracker::PoseTracker;
-use wifi_densepose_signal::ruvsense::multistatic::{MultistaticFuser, MultistaticConfig};
-use wifi_densepose_signal::ruvsense::field_model::{FieldModel, CalibrationStatus};
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
 
@@ -333,6 +332,9 @@ struct NodeState {
     motion_energy_history: VecDeque<f64>,
     /// Coherence score [0.0, 1.0]: low variance in motion_energy = high coherence.
     coherence_score: f64,
+    /// Rolling adaptive-classifier feature history (per-frame 15-dim vectors),
+    /// used by the optional temporal model trained from labeled bursts.
+    pub(crate) adaptive_feature_history: VecDeque<[f64; N_FEATURES]>,
     /// ADR-084 Pass 3 cluster-Pi novelty sensor — per-node sketch bank of
     /// recent CSI feature vectors. Populated by `update_novelty` on each
     /// frame; left `None` to disable the sensor on a per-node basis.
@@ -391,6 +393,7 @@ impl NodeState {
             prev_keypoints: None,
             motion_energy_history: VecDeque::with_capacity(COHERENCE_WINDOW),
             coherence_score: 1.0, // assume stable initially
+            adaptive_feature_history: VecDeque::with_capacity(FRAME_HISTORY_CAPACITY),
             feature_history: Some(
                 wifi_densepose_signal::ruvsense::longitudinal::EmbeddingHistory::with_sketch(
                     NOVELTY_VECTOR_DIM,
@@ -448,9 +451,12 @@ impl NodeState {
         }
 
         let mean: f64 = self.motion_energy_history.iter().sum::<f64>() / n as f64;
-        let variance: f64 = self.motion_energy_history.iter()
+        let variance: f64 = self
+            .motion_energy_history
+            .iter()
             .map(|v| (v - mean) * (v - mean))
-            .sum::<f64>() / (n - 1) as f64;
+            .sum::<f64>()
+            / (n - 1) as f64;
 
         // Map variance to [0, 1] coherence: higher variance = lower coherence.
         self.coherence_score = (1.0 / (1.0 + variance)).clamp(0.0, 1.0);
@@ -662,14 +668,18 @@ impl AppStateInner {
                     &self.frame_history
                 } else {
                     // Find the node with the most recent frame
-                    self.node_states.values()
+                    self.node_states
+                        .values()
                         .filter(|ns| !ns.frame_history.is_empty())
                         .max_by_key(|ns| ns.last_frame_time)
                         .map(|ns| &ns.frame_history)
                         .unwrap_or(&self.frame_history)
                 };
                 field_bridge::occupancy_or_fallback(
-                    fm, history, self.smoothed_person_score, self.prev_person_count,
+                    fm,
+                    history,
+                    self.smoothed_person_score,
+                    self.prev_person_count,
                 )
             }
             None => score_to_person_count(self.smoothed_person_score, self.prev_person_count),
@@ -689,8 +699,8 @@ impl AppStateInner {
 }
 
 /// Number of frames retained in `frame_history` for temporal analysis.
-/// At 500 ms ticks this covers ~50 seconds; at 100 ms ticks ~10 seconds.
-const FRAME_HISTORY_CAPACITY: usize = 100;
+/// Covers the temporal adaptive-classifier window (512 frames) plus margin.
+const FRAME_HISTORY_CAPACITY: usize = 640;
 
 type SharedState = Arc<RwLock<AppStateInner>>;
 
@@ -786,7 +796,10 @@ fn parse_wasm_output(buf: &[u8]) -> Option<WasmOutputPacket> {
         }
         let event_type = buf[offset];
         let value = f32::from_le_bytes([
-            buf[offset + 1], buf[offset + 2], buf[offset + 3], buf[offset + 4],
+            buf[offset + 1],
+            buf[offset + 2],
+            buf[offset + 3],
+            buf[offset + 4],
         ]);
         events.push(WasmEvent { event_type, value });
         offset += 5;
@@ -829,7 +842,11 @@ fn parse_esp32_frame(buf: &[u8]) -> Option<Esp32Frame> {
     let sequence = u32::from_le_bytes([buf[10], buf[11], buf[12], buf[13]]);
     let rssi_raw = buf[14] as i8;
     // Fix RSSI sign: ensure it's always negative (dBm convention).
-    let rssi = if rssi_raw > 0 { rssi_raw.saturating_neg() } else { rssi_raw };
+    let rssi = if rssi_raw > 0 {
+        rssi_raw.saturating_neg()
+    } else {
+        rssi_raw
+    };
     let noise_floor = buf[15] as i8;
 
     let iq_start = 20;
@@ -943,7 +960,8 @@ fn generate_signal_field(
                 let dx = x as f64 - center;
                 let dz = z as f64 - center;
                 let dist = (dx * dx + dz * dz).sqrt();
-                let ring_val = 0.08 * (-(dist - ring_r).powi(2) / (2.0 * ring_width * ring_width)).exp();
+                let ring_val =
+                    0.08 * (-(dist - ring_r).powi(2) / (2.0 * ring_width * ring_width)).exp();
                 values[z * grid + x] += ring_val;
             }
         }
@@ -951,7 +969,11 @@ fn generate_signal_field(
 
     // Clamp and normalise to [0, 1].
     let field_max = values.iter().cloned().fold(0.0f64, f64::max);
-    let scale = if field_max > 1e-9 { 1.0 / field_max } else { 1.0 };
+    let scale = if field_max > 1e-9 {
+        1.0 / field_max
+    } else {
+        1.0
+    };
     for v in &mut values {
         *v = (*v * scale).clamp(0.0, 1.0);
     }
@@ -982,9 +1004,14 @@ fn estimate_breathing_rate_hz(frame_history: &VecDeque<Vec<f64>>, sample_rate_hz
     }
 
     // Build scalar time series: mean amplitude per frame.
-    let series: Vec<f64> = frame_history.iter()
+    let series: Vec<f64> = frame_history
+        .iter()
         .map(|amps| {
-            if amps.is_empty() { 0.0 } else { amps.iter().sum::<f64>() / amps.len() as f64 }
+            if amps.is_empty() {
+                0.0
+            } else {
+                amps.iter().sum::<f64>() / amps.len() as f64
+            }
         })
         .collect();
 
@@ -1062,7 +1089,11 @@ fn compute_subcarrier_importance_weights(sensitivity: &[f64]) -> Vec<f64> {
     if n == 0 {
         return vec![];
     }
-    let max_sens = sensitivity.iter().cloned().fold(f64::NEG_INFINITY, f64::max).max(1e-9);
+    let max_sens = sensitivity
+        .iter()
+        .cloned()
+        .fold(f64::NEG_INFINITY, f64::max)
+        .max(1e-9);
 
     // Compute median via a sorted copy.
     let mut sorted = sensitivity.to_vec();
@@ -1144,22 +1175,33 @@ fn extract_features_from_frame(
 
     let weight_sum: f64 = importance_weights.iter().sum::<f64>();
     let mean_amp: f64 = if weight_sum > 0.0 {
-        frame.amplitudes.iter().zip(importance_weights.iter())
+        frame
+            .amplitudes
+            .iter()
+            .zip(importance_weights.iter())
             .map(|(a, w)| a * w)
-            .sum::<f64>() / weight_sum
+            .sum::<f64>()
+            / weight_sum
     } else {
         frame.amplitudes.iter().sum::<f64>() / n
     };
 
     // ── Intra-frame subcarrier variance (weighted by importance) ──
     let intra_variance: f64 = if weight_sum > 0.0 {
-        frame.amplitudes.iter().zip(importance_weights.iter())
+        frame
+            .amplitudes
+            .iter()
+            .zip(importance_weights.iter())
             .map(|(a, w)| w * (a - mean_amp).powi(2))
-            .sum::<f64>() / weight_sum
+            .sum::<f64>()
+            / weight_sum
     } else {
-        frame.amplitudes.iter()
+        frame
+            .amplitudes
+            .iter()
             .map(|a| (a - mean_amp).powi(2))
-            .sum::<f64>() / n
+            .sum::<f64>()
+            / n
     };
 
     // ── Temporal (sliding-window) per-subcarrier variance ──
@@ -1179,24 +1221,30 @@ fn extract_features_from_frame(
     // ── Motion band power (upper half of subcarriers, high spatial frequency) ──
     let half = frame.amplitudes.len() / 2;
     let motion_band_power = if half > 0 {
-        frame.amplitudes[half..].iter()
+        frame.amplitudes[half..]
+            .iter()
             .map(|a| (a - mean_amp).powi(2))
-            .sum::<f64>() / (frame.amplitudes.len() - half) as f64
+            .sum::<f64>()
+            / (frame.amplitudes.len() - half) as f64
     } else {
         0.0
     };
 
     // ── Breathing band power (lower half of subcarriers, low spatial frequency) ──
     let breathing_band_power = if half > 0 {
-        frame.amplitudes[..half].iter()
+        frame.amplitudes[..half]
+            .iter()
             .map(|a| (a - mean_amp).powi(2))
-            .sum::<f64>() / half as f64
+            .sum::<f64>()
+            / half as f64
     } else {
         0.0
     };
 
     // ── Dominant frequency via peak subcarrier index ──
-    let peak_idx = frame.amplitudes.iter()
+    let peak_idx = frame
+        .amplitudes
+        .iter()
         .enumerate()
         .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
         .map(|(i, _)| i)
@@ -1205,7 +1253,9 @@ fn extract_features_from_frame(
 
     // ── Change point detection (threshold-crossing count in current frame) ──
     let threshold = mean_amp * 1.2;
-    let change_points = frame.amplitudes.windows(2)
+    let change_points = frame
+        .amplitudes
+        .windows(2)
         .filter(|w| (w[0] < threshold) != (w[1] < threshold))
         .count();
 
@@ -1217,7 +1267,8 @@ fn extract_features_from_frame(
         if n_cmp > 0 {
             let diff_energy: f64 = (0..n_cmp)
                 .map(|k| (frame.amplitudes[k] - prev_frame[k]).powi(2))
-                .sum::<f64>() / n_cmp as f64;
+                .sum::<f64>()
+                / n_cmp as f64;
             // Normalise by mean squared amplitude to get a dimensionless ratio.
             let ref_energy = mean_amp * mean_amp + 1e-9;
             (diff_energy / ref_energy).sqrt().clamp(0.0, 1.0)
@@ -1226,7 +1277,9 @@ fn extract_features_from_frame(
         }
     } else {
         // No history yet — fall back to intra-frame variance-based estimate.
-        (intra_variance / (mean_amp * mean_amp + 1e-9)).sqrt().clamp(0.0, 1.0)
+        (intra_variance / (mean_amp * mean_amp + 1e-9))
+            .sqrt()
+            .clamp(0.0, 1.0)
     };
 
     // Blend temporal motion with variance-based motion for robustness.
@@ -1234,14 +1287,19 @@ fn extract_features_from_frame(
     let variance_motion = (temporal_variance / 10.0).clamp(0.0, 1.0);
     let mbp_motion = (motion_band_power / 25.0).clamp(0.0, 1.0);
     let cp_motion = (change_points as f64 / 15.0).clamp(0.0, 1.0);
-    let motion_score = (temporal_motion_score * 0.4 + variance_motion * 0.2 + mbp_motion * 0.25 + cp_motion * 0.15).clamp(0.0, 1.0);
+    let motion_score = (temporal_motion_score * 0.4
+        + variance_motion * 0.2
+        + mbp_motion * 0.25
+        + cp_motion * 0.15)
+        .clamp(0.0, 1.0);
 
     // ── Signal quality metric ──
     // Based on estimated SNR (RSSI relative to noise floor) and subcarrier consistency.
     let snr_db = (frame.rssi as f64 - frame.noise_floor as f64).max(0.0);
     let snr_quality = (snr_db / 40.0).clamp(0.0, 1.0); // 40 dB → quality = 1.0
-    // Penalise quality when temporal variance is very high (unstable signal).
-    let stability = (1.0 - (temporal_variance / (mean_amp * mean_amp + 1e-9)).clamp(0.0, 1.0)).max(0.0);
+                                                       // Penalise quality when temporal variance is very high (unstable signal).
+    let stability =
+        (1.0 - (temporal_variance / (mean_amp * mean_amp + 1e-9)).clamp(0.0, 1.0)).max(0.0);
     let signal_quality = (snr_quality * 0.6 + stability * 0.4).clamp(0.0, 1.0);
 
     // ── Breathing rate estimation ──
@@ -1265,15 +1323,26 @@ fn extract_features_from_frame(
         confidence: (0.4 + signal_quality * 0.3 + motion_score * 0.3).clamp(0.0, 1.0),
     };
 
-    (features, raw_classification, breathing_rate_hz, sub_variances, motion_score)
+    (
+        features,
+        raw_classification,
+        breathing_rate_hz,
+        sub_variances,
+        motion_score,
+    )
 }
 
 /// Simple threshold classification (no smoothing) — used as the "raw" input.
 fn raw_classify(score: f64) -> String {
-    if score > 0.25 { "active".into() }
-    else if score > 0.12 { "present_moving".into() }
-    else if score > 0.04 { "present_still".into() }
-    else { "absent".into() }
+    if score > 0.25 {
+        "active".into()
+    } else if score > 0.12 {
+        "present_moving".into()
+    } else if score > 0.04 {
+        "present_still".into()
+    } else {
+        "absent".into()
+    }
 }
 
 /// Debounce frames required before state transition (at ~10 FPS = ~0.4s).
@@ -1296,16 +1365,16 @@ fn smooth_and_classify(state: &mut AppStateInner, raw: &mut ClassificationInfo, 
         // During warm-up, aggressively learn the baseline.
         state.baseline_motion = state.baseline_motion * 0.9 + raw_motion * 0.1;
     } else if raw_motion < state.smoothed_motion + 0.05 {
-        state.baseline_motion = state.baseline_motion * (1.0 - BASELINE_EMA_ALPHA)
-                              + raw_motion * BASELINE_EMA_ALPHA;
+        state.baseline_motion =
+            state.baseline_motion * (1.0 - BASELINE_EMA_ALPHA) + raw_motion * BASELINE_EMA_ALPHA;
     }
 
     // 2. Subtract baseline and clamp.
     let adjusted = (raw_motion - state.baseline_motion * 0.7).max(0.0);
 
     // 3. EMA smooth the adjusted score.
-    state.smoothed_motion = state.smoothed_motion * (1.0 - MOTION_EMA_ALPHA)
-                          + adjusted * MOTION_EMA_ALPHA;
+    state.smoothed_motion =
+        state.smoothed_motion * (1.0 - MOTION_EMA_ALPHA) + adjusted * MOTION_EMA_ALPHA;
     let sm = state.smoothed_motion;
 
     // 4. Classify from smoothed score.
@@ -1342,14 +1411,14 @@ fn smooth_and_classify_node(ns: &mut NodeState, raw: &mut ClassificationInfo, ra
     if ns.baseline_frames < BASELINE_WARMUP {
         ns.baseline_motion = ns.baseline_motion * 0.9 + raw_motion * 0.1;
     } else if raw_motion < ns.smoothed_motion + 0.05 {
-        ns.baseline_motion = ns.baseline_motion * (1.0 - BASELINE_EMA_ALPHA)
-                           + raw_motion * BASELINE_EMA_ALPHA;
+        ns.baseline_motion =
+            ns.baseline_motion * (1.0 - BASELINE_EMA_ALPHA) + raw_motion * BASELINE_EMA_ALPHA;
     }
 
     let adjusted = (raw_motion - ns.baseline_motion * 0.7).max(0.0);
 
-    ns.smoothed_motion = ns.smoothed_motion * (1.0 - MOTION_EMA_ALPHA)
-                       + adjusted * MOTION_EMA_ALPHA;
+    ns.smoothed_motion =
+        ns.smoothed_motion * (1.0 - MOTION_EMA_ALPHA) + adjusted * MOTION_EMA_ALPHA;
     let sm = ns.smoothed_motion;
 
     let candidate = raw_classify(sm);
@@ -1375,10 +1444,16 @@ fn smooth_and_classify_node(ns: &mut NodeState, raw: &mut ClassificationInfo, ra
 
 /// If an adaptive model is loaded, override the classification with the
 /// model's prediction.  Uses the full 15-feature vector for higher accuracy.
-fn adaptive_override(state: &AppStateInner, features: &FeatureInfo, classification: &mut ClassificationInfo) {
+fn adaptive_override(
+    state: &AppStateInner,
+    features: &FeatureInfo,
+    classification: &mut ClassificationInfo,
+) {
     if let Some(ref model) = state.adaptive_model {
         // Get current frame amplitudes from the latest history entry.
-        let amps = state.frame_history.back()
+        let amps = state
+            .frame_history
+            .back()
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
         let feat_arr = adaptive_classifier::features_from_runtime(
@@ -1427,11 +1502,15 @@ fn smooth_vitals(state: &mut AppStateInner, raw: &VitalSigns) -> VitalSigns {
     // Push into buffer (only non-outlier values)
     if hr_ok && raw_hr > 0.0 {
         state.hr_buffer.push_back(raw_hr);
-        if state.hr_buffer.len() > VITAL_MEDIAN_WINDOW { state.hr_buffer.pop_front(); }
+        if state.hr_buffer.len() > VITAL_MEDIAN_WINDOW {
+            state.hr_buffer.pop_front();
+        }
     }
     if br_ok && raw_br > 0.0 {
         state.br_buffer.push_back(raw_br);
-        if state.br_buffer.len() > VITAL_MEDIAN_WINDOW { state.br_buffer.pop_front(); }
+        if state.br_buffer.len() > VITAL_MEDIAN_WINDOW {
+            state.br_buffer.pop_front();
+        }
     }
 
     // Compute trimmed mean: drop top/bottom 25% then average the middle 50%.
@@ -1446,8 +1525,8 @@ fn smooth_vitals(state: &mut AppStateInner, raw: &VitalSigns) -> VitalSigns {
         if state.smoothed_hr < 1.0 {
             state.smoothed_hr = trimmed_hr;
         } else if (trimmed_hr - state.smoothed_hr).abs() > HR_DEAD_BAND {
-            state.smoothed_hr = state.smoothed_hr * (1.0 - VITAL_EMA_ALPHA)
-                              + trimmed_hr * VITAL_EMA_ALPHA;
+            state.smoothed_hr =
+                state.smoothed_hr * (1.0 - VITAL_EMA_ALPHA) + trimmed_hr * VITAL_EMA_ALPHA;
         }
         // else: within dead-band, hold current value
     }
@@ -1455,8 +1534,8 @@ fn smooth_vitals(state: &mut AppStateInner, raw: &VitalSigns) -> VitalSigns {
         if state.smoothed_br < 1.0 {
             state.smoothed_br = trimmed_br;
         } else if (trimmed_br - state.smoothed_br).abs() > BR_DEAD_BAND {
-            state.smoothed_br = state.smoothed_br * (1.0 - VITAL_EMA_ALPHA)
-                              + trimmed_br * VITAL_EMA_ALPHA;
+            state.smoothed_br =
+                state.smoothed_br * (1.0 - VITAL_EMA_ALPHA) + trimmed_br * VITAL_EMA_ALPHA;
         }
     }
 
@@ -1465,8 +1544,16 @@ fn smooth_vitals(state: &mut AppStateInner, raw: &VitalSigns) -> VitalSigns {
     state.smoothed_br_conf = state.smoothed_br_conf * 0.92 + raw.breathing_confidence * 0.08;
 
     VitalSigns {
-        breathing_rate_bpm: if state.smoothed_br > 1.0 { Some(state.smoothed_br) } else { None },
-        heart_rate_bpm: if state.smoothed_hr > 1.0 { Some(state.smoothed_hr) } else { None },
+        breathing_rate_bpm: if state.smoothed_br > 1.0 {
+            Some(state.smoothed_br)
+        } else {
+            None
+        },
+        heart_rate_bpm: if state.smoothed_hr > 1.0 {
+            Some(state.smoothed_hr)
+        } else {
+            None
+        },
         breathing_confidence: state.smoothed_br_conf,
         heartbeat_confidence: state.smoothed_hr_conf,
         signal_quality: raw.signal_quality,
@@ -1483,11 +1570,15 @@ fn smooth_vitals_node(ns: &mut NodeState, raw: &VitalSigns) -> VitalSigns {
 
     if hr_ok && raw_hr > 0.0 {
         ns.hr_buffer.push_back(raw_hr);
-        if ns.hr_buffer.len() > VITAL_MEDIAN_WINDOW { ns.hr_buffer.pop_front(); }
+        if ns.hr_buffer.len() > VITAL_MEDIAN_WINDOW {
+            ns.hr_buffer.pop_front();
+        }
     }
     if br_ok && raw_br > 0.0 {
         ns.br_buffer.push_back(raw_br);
-        if ns.br_buffer.len() > VITAL_MEDIAN_WINDOW { ns.br_buffer.pop_front(); }
+        if ns.br_buffer.len() > VITAL_MEDIAN_WINDOW {
+            ns.br_buffer.pop_front();
+        }
     }
 
     let trimmed_hr = trimmed_mean(&ns.hr_buffer);
@@ -1497,16 +1588,16 @@ fn smooth_vitals_node(ns: &mut NodeState, raw: &VitalSigns) -> VitalSigns {
         if ns.smoothed_hr < 1.0 {
             ns.smoothed_hr = trimmed_hr;
         } else if (trimmed_hr - ns.smoothed_hr).abs() > HR_DEAD_BAND {
-            ns.smoothed_hr = ns.smoothed_hr * (1.0 - VITAL_EMA_ALPHA)
-                           + trimmed_hr * VITAL_EMA_ALPHA;
+            ns.smoothed_hr =
+                ns.smoothed_hr * (1.0 - VITAL_EMA_ALPHA) + trimmed_hr * VITAL_EMA_ALPHA;
         }
     }
     if trimmed_br > 0.0 {
         if ns.smoothed_br < 1.0 {
             ns.smoothed_br = trimmed_br;
         } else if (trimmed_br - ns.smoothed_br).abs() > BR_DEAD_BAND {
-            ns.smoothed_br = ns.smoothed_br * (1.0 - VITAL_EMA_ALPHA)
-                           + trimmed_br * VITAL_EMA_ALPHA;
+            ns.smoothed_br =
+                ns.smoothed_br * (1.0 - VITAL_EMA_ALPHA) + trimmed_br * VITAL_EMA_ALPHA;
         }
     }
 
@@ -1514,8 +1605,16 @@ fn smooth_vitals_node(ns: &mut NodeState, raw: &VitalSigns) -> VitalSigns {
     ns.smoothed_br_conf = ns.smoothed_br_conf * 0.92 + raw.breathing_confidence * 0.08;
 
     VitalSigns {
-        breathing_rate_bpm: if ns.smoothed_br > 1.0 { Some(ns.smoothed_br) } else { None },
-        heart_rate_bpm: if ns.smoothed_hr > 1.0 { Some(ns.smoothed_hr) } else { None },
+        breathing_rate_bpm: if ns.smoothed_br > 1.0 {
+            Some(ns.smoothed_br)
+        } else {
+            None
+        },
+        heart_rate_bpm: if ns.smoothed_hr > 1.0 {
+            Some(ns.smoothed_hr)
+        } else {
+            None
+        },
         breathing_confidence: ns.smoothed_br_conf,
         heartbeat_confidence: ns.smoothed_hr_conf,
         signal_quality: raw.signal_quality,
@@ -1525,7 +1624,9 @@ fn smooth_vitals_node(ns: &mut NodeState, raw: &VitalSigns) -> VitalSigns {
 /// Trimmed mean: sort, drop top/bottom 25%, average the middle 50%.
 /// More robust than median (uses more data) and less noisy than raw mean.
 fn trimmed_mean(buf: &VecDeque<f64>) -> f64 {
-    if buf.is_empty() { return 0.0; }
+    if buf.is_empty() {
+        return 0.0;
+    }
     let mut sorted: Vec<f64> = buf.iter().copied().collect();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let n = sorted.len();
@@ -1648,14 +1749,8 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
         let enhanced = pipeline.process(&multi_ap_frame);
 
         // ── Step 4: Build backward-compatible Esp32Frame ─────────────
-        let first_rssi = observations
-            .first()
-            .map(|o| o.rssi_dbm)
-            .unwrap_or(-80.0);
-        let _first_signal_pct = observations
-            .first()
-            .map(|o| o.signal_pct)
-            .unwrap_or(40.0);
+        let first_rssi = observations.first().map(|o| o.rssi_dbm).unwrap_or(-80.0);
+        let _first_signal_pct = observations.first().map(|o| o.signal_pct).unwrap_or(40.0);
 
         let frame = Esp32Frame {
             magic: 0xC511_0001,
@@ -1672,7 +1767,9 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
 
         // ── Step 4b: Update frame history and extract features ───────
         let mut s_write_pre = state.write().await;
-        s_write_pre.frame_history.push_back(frame.amplitudes.clone());
+        s_write_pre
+            .frame_history
+            .push_back(frame.amplitudes.clone());
         if s_write_pre.frame_history.len() > FRAME_HISTORY_CAPACITY {
             s_write_pre.frame_history.pop_front();
         }
@@ -1722,7 +1819,9 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
             0.05
         };
 
-        let raw_vitals = s.vital_detector.process_frame(&frame.amplitudes, &frame.phases);
+        let raw_vitals = s
+            .vital_detector
+            .process_frame(&frame.amplitudes, &frame.phases);
         let vitals = smooth_vitals(&mut s, &raw_vitals);
         s.latest_vitals = vitals.clone();
 
@@ -1755,8 +1854,11 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
             features,
             classification,
             signal_field: generate_signal_field(
-                first_rssi, motion_score, breathing_rate_hz,
-                feat_variance.min(1.0), &sub_variances,
+                first_rssi,
+                motion_score,
+                breathing_rate_hz,
+                feat_variance.min(1.0),
+                &sub_variances,
             ),
             vital_signs: Some(vitals),
             enhanced_motion,
@@ -1768,7 +1870,11 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
             pose_keypoints: None,
             model_status: None,
             persons: None,
-            estimated_persons: if est_persons > 0 { Some(est_persons) } else { None },
+            estimated_persons: if est_persons > 0 {
+                Some(est_persons)
+            } else {
+                None
+            },
             node_features: None,
         };
 
@@ -1776,7 +1882,9 @@ async fn windows_wifi_task(state: SharedState, tick_ms: u64) {
         let raw_persons = derive_pose_from_sensing(&update);
         let mut last_tracker_instant = s.last_tracker_instant.take();
         let tracked = tracker_bridge::tracker_update(
-            &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
+            &mut s.pose_tracker,
+            &mut last_tracker_instant,
+            raw_persons,
         );
         s.last_tracker_instant = last_tracker_instant;
         if !tracked.is_empty() {
@@ -1861,7 +1969,9 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
         0.05
     };
 
-    let raw_vitals = s.vital_detector.process_frame(&frame.amplitudes, &frame.phases);
+    let raw_vitals = s
+        .vital_detector
+        .process_frame(&frame.amplitudes, &frame.phases);
     let vitals = smooth_vitals(&mut s, &raw_vitals);
     s.latest_vitals = vitals.clone();
 
@@ -1894,8 +2004,11 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
         features,
         classification,
         signal_field: generate_signal_field(
-            rssi_dbm, motion_score, breathing_rate_hz,
-            feat_variance.min(1.0), &sub_variances,
+            rssi_dbm,
+            motion_score,
+            breathing_rate_hz,
+            feat_variance.min(1.0),
+            &sub_variances,
         ),
         vital_signs: Some(vitals),
         enhanced_motion: None,
@@ -1907,15 +2020,18 @@ async fn windows_wifi_fallback_tick(state: &SharedState, seq: u32) {
         pose_keypoints: None,
         model_status: None,
         persons: None,
-        estimated_persons: if est_persons > 0 { Some(est_persons) } else { None },
+        estimated_persons: if est_persons > 0 {
+            Some(est_persons)
+        } else {
+            None
+        },
         node_features: None,
     };
 
     let raw_persons = derive_pose_from_sensing(&update);
     let mut last_tracker_instant = s.last_tracker_instant.take();
-    let tracked = tracker_bridge::tracker_update(
-        &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
-    );
+    let tracked =
+        tracker_bridge::tracker_update(&mut s.pose_tracker, &mut last_tracker_instant, raw_persons);
     s.last_tracker_instant = last_tracker_instant;
     if !tracked.is_empty() {
         update.persons = Some(tracked);
@@ -2049,7 +2165,9 @@ async fn handle_ws_pose_client(mut socket: WebSocket, state: SharedState) {
         "type": "connection_established",
         "payload": { "status": "connected", "backend": "rust+ruvector" }
     });
-    let _ = socket.send(Message::Text(conn_msg.to_string().into())).await;
+    let _ = socket
+        .send(Message::Text(conn_msg.to_string().into()))
+        .await;
 
     loop {
         tokio::select! {
@@ -2208,8 +2326,12 @@ fn fuse_multi_node_features(
     node_states: &HashMap<u8, NodeState>,
 ) -> FeatureInfo {
     let now = std::time::Instant::now();
-    let active: Vec<(&FeatureInfo, f64)> = node_states.values()
-        .filter(|ns| ns.last_frame_time.map_or(false, |t| now.duration_since(t).as_secs() < 10))
+    let active: Vec<(&FeatureInfo, f64)> = node_states
+        .values()
+        .filter(|ns| {
+            ns.last_frame_time
+                .map_or(false, |t| now.duration_since(t).as_secs() < 10)
+        })
         .filter_map(|ns| {
             let feat = ns.latest_features.as_ref()?;
             let rssi = ns.rssi_history.back().copied().unwrap_or(-80.0);
@@ -2223,8 +2345,12 @@ fn fuse_multi_node_features(
 
     // RSSI-based weights: higher RSSI = closer to person = more weight.
     // Map RSSI relative to best node into [0.1, 1.0].
-    let max_rssi = active.iter().map(|(_, r)| *r).fold(f64::NEG_INFINITY, f64::max);
-    let weights: Vec<f64> = active.iter()
+    let max_rssi = active
+        .iter()
+        .map(|(_, r)| *r)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let weights: Vec<f64> = active
+        .iter()
         .map(|(_, r)| (1.0 + (r - max_rssi + 20.0) / 20.0).clamp(0.1, 1.0))
         .collect();
     let w_sum: f64 = weights.iter().sum::<f64>().max(1e-9);
@@ -2232,20 +2358,43 @@ fn fuse_multi_node_features(
     FeatureInfo {
         // Weighted average variance (not max — max inflates person score
         // and causes count flips between 1↔2 persons).
-        variance: active.iter().zip(&weights)
-            .map(|((f, _), w)| f.variance * w).sum::<f64>() / w_sum,
+        variance: active
+            .iter()
+            .zip(&weights)
+            .map(|((f, _), w)| f.variance * w)
+            .sum::<f64>()
+            / w_sum,
         // Weighted average for motion/breathing/spectral
-        motion_band_power: active.iter().zip(&weights)
-            .map(|((f, _), w)| f.motion_band_power * w).sum::<f64>() / w_sum,
-        breathing_band_power: active.iter().zip(&weights)
-            .map(|((f, _), w)| f.breathing_band_power * w).sum::<f64>() / w_sum,
-        spectral_power: active.iter().zip(&weights)
-            .map(|((f, _), w)| f.spectral_power * w).sum::<f64>() / w_sum,
-        dominant_freq_hz: active.iter().zip(&weights)
-            .map(|((f, _), w)| f.dominant_freq_hz * w).sum::<f64>() / w_sum,
+        motion_band_power: active
+            .iter()
+            .zip(&weights)
+            .map(|((f, _), w)| f.motion_band_power * w)
+            .sum::<f64>()
+            / w_sum,
+        breathing_band_power: active
+            .iter()
+            .zip(&weights)
+            .map(|((f, _), w)| f.breathing_band_power * w)
+            .sum::<f64>()
+            / w_sum,
+        spectral_power: active
+            .iter()
+            .zip(&weights)
+            .map(|((f, _), w)| f.spectral_power * w)
+            .sum::<f64>()
+            / w_sum,
+        dominant_freq_hz: active
+            .iter()
+            .zip(&weights)
+            .map(|((f, _), w)| f.dominant_freq_hz * w)
+            .sum::<f64>()
+            / w_sum,
         change_points: current_features.change_points, // keep current node's value
         // Best RSSI across nodes
-        mean_rssi: active.iter().map(|(f, _)| f.mean_rssi).fold(f64::NEG_INFINITY, f64::max),
+        mean_rssi: active
+            .iter()
+            .map(|(f, _)| f.mean_rssi)
+            .fold(f64::NEG_INFINITY, f64::max),
     }
 }
 
@@ -2311,7 +2460,9 @@ fn estimate_persons_from_correlation(frame_history: &VecDeque<Vec<f64>>) -> usiz
 
     // Active subcarriers: variance above noise floor
     let noise_floor = 1.0;
-    let active: Vec<usize> = (0..n_sub).filter(|&sc| variances[sc] > noise_floor).collect();
+    let active: Vec<usize> = (0..n_sub)
+        .filter(|&sc| variances[sc] > noise_floor)
+        .collect();
     let m = active.len();
     if m < 3 {
         return if m == 0 { 0 } else { 1 };
@@ -2324,7 +2475,10 @@ fn estimate_persons_from_correlation(frame_history: &VecDeque<Vec<f64>>) -> usiz
     let sink = (m + 1) as u64;
 
     // Precompute std devs
-    let stds: Vec<f64> = active.iter().map(|&sc| variances[sc].sqrt().max(1e-9)).collect();
+    let stds: Vec<f64> = active
+        .iter()
+        .map(|&sc| variances[sc].sqrt().max(1e-9))
+        .collect();
 
     for i in 0..m {
         for j in (i + 1)..m {
@@ -2348,10 +2502,14 @@ fn estimate_persons_from_correlation(frame_history: &VecDeque<Vec<f64>>) -> usiz
     }
 
     // Source → highest-variance subcarrier, Sink → lowest-variance
-    let (max_var_idx, _) = active.iter().enumerate()
+    let (max_var_idx, _) = active
+        .iter()
+        .enumerate()
         .max_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap())
         .unwrap_or((0, &0));
-    let (min_var_idx, _) = active.iter().enumerate()
+    let (min_var_idx, _) = active
+        .iter()
+        .enumerate()
         .min_by(|(_, &a), (_, &b)| variances[a].partial_cmp(&variances[b]).unwrap())
         .unwrap_or((0, &0));
 
@@ -2363,16 +2521,22 @@ fn estimate_persons_from_correlation(frame_history: &VecDeque<Vec<f64>>) -> usiz
     edges.push((min_var_idx as u64, sink, 100.0));
 
     // Run min-cut
-    let mc: DynamicMinCut = match MinCutBuilder::new().exact().with_edges(edges.clone()).build() {
+    let mc: DynamicMinCut = match MinCutBuilder::new()
+        .exact()
+        .with_edges(edges.clone())
+        .build()
+    {
         Ok(mc) => mc,
         Err(_) => return 1,
     };
 
     let cut_value = mc.min_cut_value();
-    let total_edge_weight: f64 = edges.iter()
+    let total_edge_weight: f64 = edges
+        .iter()
         .filter(|(s, t, _)| *s != source && *s != sink && *t != source && *t != sink)
         .map(|(_, _, w)| w)
-        .sum::<f64>() / 2.0; // bidirectional → halve
+        .sum::<f64>()
+        / 2.0; // bidirectional → halve
 
     if total_edge_weight < 1e-9 {
         return 1;
@@ -2405,9 +2569,9 @@ fn score_to_person_count(smoothed_score: f64, prev_count: usize) -> usize {
     //   3→2: 0.78  (hysteresis gap of 0.14)
     match prev_count {
         0 | 1 => {
-            if smoothed_score > 0.85 {
+            if smoothed_score > 0.92 {
                 3
-            } else if smoothed_score > 0.70 {
+            } else if smoothed_score > 0.80 {
                 2
             } else {
                 1
@@ -2475,7 +2639,8 @@ fn derive_single_person_pose(
     let lean_x = (feat.dominant_freq_hz / 5.0 - 1.0).clamp(-1.0, 1.0) * 18.0;
 
     let stride_x = if is_walking {
-        let stride_phase = (feat.motion_band_power * 0.7 + update.tick as f64 * 0.06 + phase_offset).sin();
+        let stride_phase =
+            (feat.motion_band_power * 0.7 + update.tick as f64 * 0.06 + phase_offset).sin();
         stride_phase * 20.0 * motion_score
     } else {
         0.0
@@ -2500,36 +2665,51 @@ fn derive_single_person_pose(
     // ── COCO 17-keypoint offsets from hip-center ──────────────────────────────
 
     let kp_names = [
-        "nose", "left_eye", "right_eye", "left_ear", "right_ear",
-        "left_shoulder", "right_shoulder", "left_elbow", "right_elbow",
-        "left_wrist", "right_wrist", "left_hip", "right_hip",
-        "left_knee", "right_knee", "left_ankle", "right_ankle",
+        "nose",
+        "left_eye",
+        "right_eye",
+        "left_ear",
+        "right_ear",
+        "left_shoulder",
+        "right_shoulder",
+        "left_elbow",
+        "right_elbow",
+        "left_wrist",
+        "right_wrist",
+        "left_hip",
+        "right_hip",
+        "left_knee",
+        "right_knee",
+        "left_ankle",
+        "right_ankle",
     ];
 
     let kp_offsets: [(f64, f64); 17] = [
-        (  0.0,  -80.0), // 0  nose
-        ( -8.0,  -88.0), // 1  left_eye
-        (  8.0,  -88.0), // 2  right_eye
-        (-16.0,  -82.0), // 3  left_ear
-        ( 16.0,  -82.0), // 4  right_ear
-        (-30.0,  -50.0), // 5  left_shoulder
-        ( 30.0,  -50.0), // 6  right_shoulder
-        (-45.0,  -15.0), // 7  left_elbow
-        ( 45.0,  -15.0), // 8  right_elbow
-        (-50.0,   20.0), // 9  left_wrist
-        ( 50.0,   20.0), // 10 right_wrist
-        (-20.0,   20.0), // 11 left_hip
-        ( 20.0,   20.0), // 12 right_hip
-        (-22.0,   70.0), // 13 left_knee
-        ( 22.0,   70.0), // 14 right_knee
-        (-24.0,  120.0), // 15 left_ankle
-        ( 24.0,  120.0), // 16 right_ankle
+        (0.0, -80.0),   // 0  nose
+        (-8.0, -88.0),  // 1  left_eye
+        (8.0, -88.0),   // 2  right_eye
+        (-16.0, -82.0), // 3  left_ear
+        (16.0, -82.0),  // 4  right_ear
+        (-30.0, -50.0), // 5  left_shoulder
+        (30.0, -50.0),  // 6  right_shoulder
+        (-45.0, -15.0), // 7  left_elbow
+        (45.0, -15.0),  // 8  right_elbow
+        (-50.0, 20.0),  // 9  left_wrist
+        (50.0, 20.0),   // 10 right_wrist
+        (-20.0, 20.0),  // 11 left_hip
+        (20.0, 20.0),   // 12 right_hip
+        (-22.0, 70.0),  // 13 left_knee
+        (22.0, 70.0),   // 14 right_knee
+        (-24.0, 120.0), // 15 left_ankle
+        (24.0, 120.0),  // 16 right_ankle
     ];
 
     const TORSO_KP: [usize; 4] = [5, 6, 11, 12];
     const EXTREMITY_KP: [usize; 4] = [9, 10, 15, 16];
 
-    let keypoints: Vec<PoseKeypoint> = kp_names.iter().zip(kp_offsets.iter())
+    let keypoints: Vec<PoseKeypoint> = kp_names
+        .iter()
+        .zip(kp_offsets.iter())
         .enumerate()
         .map(|(i, (name, (dx, dy)))| {
             let breath_dx = if TORSO_KP.contains(&i) {
@@ -2557,17 +2737,20 @@ fn derive_single_person_pose(
             };
 
             let kp_noise_x = ((noise_seed + i as f64 * 1.618).sin() * 43758.545).fract()
-                * feat.variance.sqrt().clamp(0.0, 3.0) * motion_score;
+                * feat.variance.sqrt().clamp(0.0, 3.0)
+                * motion_score;
             let kp_noise_y = ((noise_seed + i as f64 * 2.718).cos() * 31415.926).fract()
-                * feat.variance.sqrt().clamp(0.0, 3.0) * motion_score * 0.6;
+                * feat.variance.sqrt().clamp(0.0, 3.0)
+                * motion_score
+                * 0.6;
 
             let swing_dy = if is_walking {
                 let stride_phase =
                     (feat.motion_band_power * 0.7 + update.tick as f64 * 0.12 + phase_offset).sin();
                 match i {
-                    7 | 9  => -stride_phase * 20.0 * motion_score,
-                    8 | 10 =>  stride_phase * 20.0 * motion_score,
-                    13 | 15 =>  stride_phase * 25.0 * motion_score,
+                    7 | 9 => -stride_phase * 20.0 * motion_score,
+                    8 | 10 => stride_phase * 20.0 * motion_score,
+                    13 | 15 => stride_phase * 25.0 * motion_score,
                     14 | 16 => -stride_phase * 25.0 * motion_score,
                     _ => 0.0,
                 }
@@ -2634,10 +2817,18 @@ fn derive_pose_from_sensing(update: &SensingUpdate) -> Vec<PersonDetection> {
 /// Expected bone lengths in pixel-space for the COCO-17 skeleton as used by
 /// `derive_single_person_pose`. Pairs are (parent_idx, child_idx).
 const POSE_BONE_PAIRS: &[(usize, usize)] = &[
-    (5, 7), (7, 9), (6, 8), (8, 10),   // arms
-    (5, 11), (6, 12),                     // torso
-    (11, 13), (13, 15), (12, 14), (14, 16), // legs
-    (5, 6), (11, 12),                     // shoulders, hips
+    (5, 7),
+    (7, 9),
+    (6, 8),
+    (8, 10), // arms
+    (5, 11),
+    (6, 12), // torso
+    (11, 13),
+    (13, 15),
+    (12, 14),
+    (14, 16), // legs
+    (5, 6),
+    (11, 12), // shoulders, hips
 ];
 
 /// Apply temporal EMA smoothing and bone-length clamping to person detections.
@@ -2652,7 +2843,9 @@ fn apply_temporal_smoothing(persons: &mut [PersonDetection], ns: &mut NodeState)
     let alpha = ns.ema_alpha();
     let person = &mut persons[0]; // smooth primary person only
 
-    let current_kps: Vec<[f64; 3]> = person.keypoints.iter()
+    let current_kps: Vec<[f64; 3]> = person
+        .keypoints
+        .iter()
         .map(|kp| [kp.x, kp.y, kp.z])
         .collect();
 
@@ -2800,7 +2993,24 @@ async fn api_info(State(state): State<SharedState>) -> Json<serde_json::Value> {
 async fn pose_current(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
     let persons = match &s.latest_update {
-        Some(update) => update.persons.clone().unwrap_or_else(|| derive_pose_from_sensing(update)),
+        Some(update) => {
+            // Cap tracker output at the score-path's estimate. The Kalman tracker
+            // can accumulate ghost tracks because synthetic skeleton positions jump
+            // between ESP32 nodes; the score path is the authoritative count.
+            let limit = update.estimated_persons.unwrap_or_else(|| {
+                if update.classification.presence {
+                    1
+                } else {
+                    0
+                }
+            });
+            let mut ps = update
+                .persons
+                .clone()
+                .unwrap_or_else(|| derive_pose_from_sensing(update));
+            ps.truncate(limit);
+            ps
+        }
         None => vec![],
     };
     Json(serde_json::json!({
@@ -2823,8 +3033,11 @@ async fn pose_stats(State(state): State<SharedState>) -> Json<serde_json::Value>
 
 async fn pose_zones_summary(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
-    let presence = s.latest_update.as_ref()
-        .map(|u| u.classification.presence).unwrap_or(false);
+    let presence = s
+        .latest_update
+        .as_ref()
+        .map(|u| u.classification.presence)
+        .unwrap_or(false);
     Json(serde_json::json!({
         "zones": {
             "zone_1": { "person_count": if presence { 1 } else { 0 }, "status": "monitored" },
@@ -2864,9 +3077,10 @@ async fn get_active_model(State(state): State<SharedState>) -> Json<serde_json::
     let s = state.read().await;
     match &s.active_model_id {
         Some(id) => {
-            let model = s.discovered_models.iter().find(|m| {
-                m.get("id").and_then(|v| v.as_str()) == Some(id.as_str())
-            });
+            let model = s
+                .discovered_models
+                .iter()
+                .find(|m| m.get("id").and_then(|v| v.as_str()) == Some(id.as_str()));
             Json(serde_json::json!({
                 "active": model.cloned().unwrap_or_else(|| serde_json::json!({ "id": id })),
             }))
@@ -2880,7 +3094,8 @@ async fn load_model(
     State(state): State<SharedState>,
     Json(body): Json<serde_json::Value>,
 ) -> Json<serde_json::Value> {
-    let model_id = body.get("id")
+    let model_id = body
+        .get("id")
         .or_else(|| body.get("model_id"))
         .and_then(|v| v.as_str())
         .unwrap_or("")
@@ -2921,7 +3136,9 @@ async fn delete_model(
     if path.exists() {
         if let Err(e) = std::fs::remove_file(&path) {
             warn!("Failed to delete model file {:?}: {}", path, e);
-            return Json(serde_json::json!({ "error": format!("delete failed: {e}"), "success": false }));
+            return Json(
+                serde_json::json!({ "error": format!("delete failed: {e}"), "success": false }),
+            );
         }
         // If this was the active model, unload it
         let mut s = state.write().await;
@@ -2929,9 +3146,8 @@ async fn delete_model(
             s.active_model_id = None;
             s.model_loaded = false;
         }
-        s.discovered_models.retain(|m| {
-            m.get("id").and_then(|v| v.as_str()) != Some(id.as_str())
-        });
+        s.discovered_models
+            .retain(|m| m.get("id").and_then(|v| v.as_str()) != Some(id.as_str()));
         info!("Model deleted: {id}");
         Json(serde_json::json!({ "success": true, "deleted": id }))
     } else {
@@ -2947,10 +3163,9 @@ async fn list_lora_profiles() -> Json<serde_json::Value> {
 }
 
 /// POST /api/v1/models/lora/activate — activate a LoRA adapter profile.
-async fn activate_lora_profile(
-    Json(body): Json<serde_json::Value>,
-) -> Json<serde_json::Value> {
-    let profile = body.get("profile")
+async fn activate_lora_profile(Json(body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+    let profile = body
+        .get("profile")
         .or_else(|| body.get("name"))
         .and_then(|v| v.as_str())
         .unwrap_or("")
@@ -2965,9 +3180,7 @@ async fn activate_lora_profile(
 /// Return the effective models directory, respecting the `MODELS_DIR`
 /// environment variable.  Defaults to `data/models`.
 fn effective_models_dir() -> PathBuf {
-    PathBuf::from(
-        std::env::var("MODELS_DIR").unwrap_or_else(|_| "data/models".to_string()),
-    )
+    PathBuf::from(std::env::var("MODELS_DIR").unwrap_or_else(|_| "data/models".to_string()))
 }
 
 /// Scan the models directory for `.rvf` files and return metadata.
@@ -2979,12 +3192,15 @@ fn scan_model_files() -> Vec<serde_json::Value> {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) == Some("rvf") {
-                let name = path.file_stem()
+                let name = path
+                    .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("unknown")
                     .to_string();
                 let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
-                let modified = entry.metadata().ok()
+                let modified = entry
+                    .metadata()
+                    .ok()
                     .and_then(|m| m.modified().ok())
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| d.as_secs())
@@ -3051,12 +3267,11 @@ async fn start_recording(
             "recording_id": s.recording_current_id,
         }));
     }
-    let id = body.get("id")
+    let id = body
+        .get("id")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .unwrap_or_else(|| {
-            format!("rec_{}", chrono_timestamp())
-        });
+        .unwrap_or_else(|| format!("rec_{}", chrono_timestamp()));
 
     // Create the recording file
     let rec_path = PathBuf::from("data/recordings").join(format!("{}.jsonl", id));
@@ -3150,7 +3365,8 @@ async fn stop_recording(State(state): State<SharedState>) -> Json<serde_json::Va
     if let Some(tx) = s.recording_stop_tx.take() {
         let _ = tx.send(true);
     }
-    let duration_secs = s.recording_start_time
+    let duration_secs = s
+        .recording_start_time
         .map(|t| t.elapsed().as_secs())
         .unwrap_or(0);
     let rec_id = s.recording_current_id.take().unwrap_or_default();
@@ -3190,12 +3406,13 @@ async fn delete_recording(
     if path.exists() {
         if let Err(e) = std::fs::remove_file(&path) {
             warn!("Failed to delete recording {:?}: {}", path, e);
-            return Json(serde_json::json!({ "error": format!("delete failed: {e}"), "success": false }));
+            return Json(
+                serde_json::json!({ "error": format!("delete failed: {e}"), "success": false }),
+            );
         }
         let mut s = state.write().await;
-        s.recordings.retain(|r| {
-            r.get("id").and_then(|v| v.as_str()) != Some(id.as_str())
-        });
+        s.recordings
+            .retain(|r| r.get("id").and_then(|v| v.as_str()) != Some(id.as_str()));
         info!("Recording deleted: {id}");
         Json(serde_json::json!({ "success": true, "deleted": id }))
     } else {
@@ -3211,12 +3428,15 @@ fn scan_recording_files() -> Vec<serde_json::Value> {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                let name = path.file_stem()
+                let name = path
+                    .file_stem()
                     .and_then(|s| s.to_str())
                     .unwrap_or("unknown")
                     .to_string();
                 let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
-                let modified = entry.metadata().ok()
+                let modified = entry
+                    .metadata()
+                    .ok()
                     .and_then(|m| m.modified().ok())
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| d.as_secs())
@@ -3300,19 +3520,26 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
         Ok(model) => {
             let accuracy = model.training_accuracy;
             let frames = model.trained_frames;
-            let stats: Vec<_> = model.class_stats.iter().map(|cs| {
-                serde_json::json!({
-                    "class": cs.label,
-                    "samples": cs.count,
-                    "feature_means": cs.mean,
+            let stats: Vec<_> = model
+                .class_stats
+                .iter()
+                .map(|cs| {
+                    serde_json::json!({
+                        "class": cs.label,
+                        "samples": cs.count,
+                        "feature_means": cs.mean,
+                    })
                 })
-            }).collect();
+                .collect();
 
             // Save to disk.
             if let Err(e) = model.save(&adaptive_classifier::model_path()) {
                 warn!("Failed to save adaptive model: {e}");
             } else {
-                info!("Adaptive model saved to {}", adaptive_classifier::model_path().display());
+                info!(
+                    "Adaptive model saved to {}",
+                    adaptive_classifier::model_path().display()
+                );
             }
 
             // Load into runtime state.
@@ -3326,12 +3553,10 @@ async fn adaptive_train(State(state): State<SharedState>) -> Json<serde_json::Va
                 "class_stats": stats,
             }))
         }
-        Err(e) => {
-            Json(serde_json::json!({
-                "success": false,
-                "error": e,
-            }))
-        }
+        Err(e) => Json(serde_json::json!({
+            "success": false,
+            "error": e,
+        })),
     }
 }
 
@@ -3593,21 +3818,39 @@ async fn sona_activate(
 async fn nodes_endpoint(State(state): State<SharedState>) -> Json<serde_json::Value> {
     let s = state.read().await;
     let now = std::time::Instant::now();
-    let nodes: Vec<serde_json::Value> = s.node_states.iter()
+    let latest_absent = s
+        .latest_update
+        .as_ref()
+        .map(|u| !u.classification.presence)
+        .unwrap_or(false);
+    let nodes: Vec<serde_json::Value> = s
+        .node_states
+        .iter()
         .map(|(&id, ns)| {
-            let elapsed_ms = ns.last_frame_time
+            let elapsed_ms = ns
+                .last_frame_time
                 .map(|t| now.duration_since(t).as_millis() as u64)
                 .unwrap_or(999999);
             let stale = elapsed_ms > 5000;
             let status = if stale { "stale" } else { "active" };
             let rssi = ns.rssi_history.back().copied().unwrap_or(-90.0);
+            let motion_level = if latest_absent && !stale {
+                "absent"
+            } else {
+                ns.current_motion_level.as_str()
+            };
+            let person_count = if latest_absent && !stale {
+                0
+            } else {
+                ns.prev_person_count
+            };
             serde_json::json!({
                 "node_id": id,
                 "status": status,
                 "last_seen_ms": elapsed_ms,
                 "rssi_dbm": rssi,
-                "motion_level": &ns.current_motion_level,
-                "person_count": ns.prev_person_count,
+                "motion_level": motion_level,
+                "person_count": person_count,
             })
         })
         .collect();
@@ -3654,9 +3897,13 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
             Ok((len, src)) => {
                 // ADR-039: Try edge vitals packet first (magic 0xC511_0002).
                 if let Some(vitals) = parse_esp32_vitals(&buf[..len]) {
-                    debug!("ESP32 vitals from {src}: node={} br={:.1} hr={:.1} pres={}",
-                           vitals.node_id, vitals.breathing_rate_bpm,
-                           vitals.heartrate_bpm, vitals.presence);
+                    debug!(
+                        "ESP32 vitals from {src}: node={} br={:.1} hr={:.1} pres={}",
+                        vitals.node_id,
+                        vitals.breathing_rate_bpm,
+                        vitals.heartrate_bpm,
+                        vitals.presence
+                    );
                     let mut s = state.write().await;
                     // Broadcast vitals via WebSocket.
                     if let Ok(json) = serde_json::to_string(&serde_json::json!({
@@ -3688,7 +3935,9 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     ns.last_frame_time = Some(std::time::Instant::now());
                     ns.edge_vitals = Some(vitals.clone());
                     ns.rssi_history.push_back(vitals.rssi as f64);
-                    if ns.rssi_history.len() > 60 { ns.rssi_history.pop_front(); }
+                    if ns.rssi_history.len() > 60 {
+                        ns.rssi_history.pop_front();
+                    }
 
                     // Store per-node person count from edge vitals.
                     let node_est = if vitals.presence {
@@ -3701,23 +3950,36 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     s.tick += 1;
                     let tick = s.tick;
 
-                    let motion_level = if vitals.motion { "present_moving" }
-                        else if vitals.presence { "present_still" }
-                        else { "absent" };
-                    let motion_score = if vitals.motion { 0.8 }
-                        else if vitals.presence { 0.3 }
-                        else { 0.05 };
+                    let motion_level = if vitals.motion {
+                        "present_moving"
+                    } else if vitals.presence {
+                        "present_still"
+                    } else {
+                        "absent"
+                    };
+                    let motion_score = if vitals.motion {
+                        0.8
+                    } else if vitals.presence {
+                        0.3
+                    } else {
+                        0.05
+                    };
 
                     // Aggregate person count: gate on presence first (matching WiFi path).
                     let now = std::time::Instant::now();
                     let total_persons = if vitals.presence {
                         let (fused, fallback_count) = multistatic_bridge::fuse_or_fallback(
-                            &s.multistatic_fuser, &s.node_states,
+                            &s.multistatic_fuser,
+                            &s.node_states,
                         );
                         match fused {
                             Some(ref f) => {
-                                let score = multistatic_bridge::compute_person_score_from_amplitudes(&f.fused_amplitude);
-                                s.smoothed_person_score = s.smoothed_person_score * 0.90 + score * 0.10;
+                                let score =
+                                    multistatic_bridge::compute_person_score_from_amplitudes(
+                                        &f.fused_amplitude,
+                                    );
+                                s.smoothed_person_score =
+                                    s.smoothed_person_score * 0.90 + score * 0.10;
                                 let count = s.person_count();
                                 s.prev_person_count = count;
                                 count.max(1) // presence=true => at least 1
@@ -3730,15 +3992,24 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     };
 
                     // Feed field model calibration if active (use per-node history for ESP32).
-                    if let Some(frame_history) = s.node_states.get(&node_id).map(|ns| ns.frame_history.clone()) {
+                    if let Some(frame_history) = s
+                        .node_states
+                        .get(&node_id)
+                        .map(|ns| ns.frame_history.clone())
+                    {
                         if let Some(ref mut fm) = s.field_model {
                             field_bridge::maybe_feed_calibration(fm, &frame_history);
                         }
                     }
 
                     // Build nodes array with all active nodes.
-                    let active_nodes: Vec<NodeInfo> = s.node_states.iter()
-                        .filter(|(_, n)| n.last_frame_time.map_or(false, |t| now.duration_since(t).as_secs() < 10))
+                    let active_nodes: Vec<NodeInfo> = s
+                        .node_states
+                        .iter()
+                        .filter(|(_, n)| {
+                            n.last_frame_time
+                                .map_or(false, |t| now.duration_since(t).as_secs() < 10)
+                        })
                         .map(|(&id, n)| NodeInfo {
                             node_id: id,
                             rssi_dbm: n.rssi_history.back().copied().unwrap_or(0.0),
@@ -3759,7 +4030,8 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     };
 
                     // Store latest features on node for cross-node fusion.
-                    s.node_states.get_mut(&node_id)
+                    s.node_states
+                        .get_mut(&node_id)
                         .map(|ns| ns.latest_features = Some(features.clone()));
 
                     // Cross-node fusion: combine features from all active nodes.
@@ -3772,17 +4044,26 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     };
 
                     // Boost classification confidence with multi-node coverage.
-                    let n_active = s.node_states.values()
-                        .filter(|ns| ns.last_frame_time.map_or(false, |t| now.duration_since(t).as_secs() < 10))
+                    let n_active = s
+                        .node_states
+                        .values()
+                        .filter(|ns| {
+                            ns.last_frame_time
+                                .map_or(false, |t| now.duration_since(t).as_secs() < 10)
+                        })
                         .count();
                     if n_active > 1 {
                         classification.confidence = (classification.confidence
-                            * (1.0 + 0.15 * (n_active as f64 - 1.0))).clamp(0.0, 1.0);
+                            * (1.0 + 0.15 * (n_active as f64 - 1.0)))
+                            .clamp(0.0, 1.0);
                     }
 
                     let signal_field = generate_signal_field(
-                        fused_features.mean_rssi, motion_score, vitals.breathing_rate_bpm / 60.0,
-                        (vitals.presence_score as f64).min(1.0), &[],
+                        fused_features.mean_rssi,
+                        motion_score,
+                        vitals.breathing_rate_bpm / 60.0,
+                        (vitals.presence_score as f64).min(1.0),
+                        &[],
                     );
 
                     let mut update = SensingUpdate {
@@ -3795,8 +4076,16 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         classification,
                         signal_field,
                         vital_signs: Some(VitalSigns {
-                            breathing_rate_bpm: if vitals.breathing_rate_bpm > 0.0 { Some(vitals.breathing_rate_bpm) } else { None },
-                            heart_rate_bpm: if vitals.heartrate_bpm > 0.0 { Some(vitals.heartrate_bpm) } else { None },
+                            breathing_rate_bpm: if vitals.breathing_rate_bpm > 0.0 {
+                                Some(vitals.breathing_rate_bpm)
+                            } else {
+                                None
+                            },
+                            heart_rate_bpm: if vitals.heartrate_bpm > 0.0 {
+                                Some(vitals.heartrate_bpm)
+                            } else {
+                                None
+                            },
                             breathing_confidence: if vitals.presence { 0.7 } else { 0.0 },
                             heartbeat_confidence: if vitals.presence { 0.7 } else { 0.0 },
                             signal_quality: vitals.presence_score as f64,
@@ -3810,7 +4099,11 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         pose_keypoints: None,
                         model_status: None,
                         persons: None,
-                        estimated_persons: if total_persons > 0 { Some(total_persons) } else { None },
+                        estimated_persons: if total_persons > 0 {
+                            Some(total_persons)
+                        } else {
+                            None
+                        },
                         // ADR-084 Pass 3.6: surface per-node novelty_score
                         // (and the rest of the per-node feature snapshot)
                         // on the WebSocket envelope so cluster-Pi consumers
@@ -3822,7 +4115,9 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     let raw_persons = derive_pose_from_sensing(&update);
                     let mut last_tracker_instant = s.last_tracker_instant.take();
                     let tracked = tracker_bridge::tracker_update(
-                        &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
+                        &mut s.pose_tracker,
+                        &mut last_tracker_instant,
+                        raw_persons,
                     );
                     s.last_tracker_instant = last_tracker_instant;
                     if !tracked.is_empty() {
@@ -3839,9 +4134,12 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
 
                 // ADR-040: Try WASM output packet (magic 0xC511_0004).
                 if let Some(wasm_output) = parse_wasm_output(&buf[..len]) {
-                    debug!("WASM output from {src}: node={} module={} events={}",
-                           wasm_output.node_id, wasm_output.module_id,
-                           wasm_output.events.len());
+                    debug!(
+                        "WASM output from {src}: node={} module={} events={}",
+                        wasm_output.node_id,
+                        wasm_output.module_id,
+                        wasm_output.events.len()
+                    );
                     let mut s = state.write().await;
                     // Broadcast WASM events via WebSocket.
                     if let Ok(json) = serde_json::to_string(&serde_json::json!({
@@ -3857,8 +4155,10 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                 }
 
                 if let Some(frame) = parse_esp32_frame(&buf[..len]) {
-                    debug!("ESP32 frame from {src}: node={}, subs={}, seq={}",
-                           frame.node_id, frame.n_subcarriers, frame.sequence);
+                    debug!(
+                        "ESP32 frame from {src}: node={}, subs={}, seq={}",
+                        frame.node_id, frame.n_subcarriers, frame.sequence
+                    );
 
                     let mut s = state.write().await;
                     s.source = "esp32".to_string();
@@ -3897,15 +4197,18 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     }
 
                     let sample_rate_hz = 1000.0 / 500.0_f64;
-                    let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
-                        extract_features_from_frame(&frame, &ns.frame_history, sample_rate_hz);
+                    let (
+                        features,
+                        mut classification,
+                        breathing_rate_hz,
+                        sub_variances,
+                        raw_motion,
+                    ) = extract_features_from_frame(&frame, &ns.frame_history, sample_rate_hz);
                     smooth_and_classify_node(ns, &mut classification, raw_motion);
 
                     // Adaptive override using cloned model (safe, no raw pointers).
                     if let Some(ref model) = adaptive_model_clone {
-                        let amps = ns.frame_history.back()
-                            .map(|v| v.as_slice())
-                            .unwrap_or(&[]);
+                        let amps = ns.frame_history.back().map(|v| v.as_slice()).unwrap_or(&[]);
                         let feat_arr = adaptive_classifier::features_from_runtime(
                             &serde_json::json!({
                                 "variance": features.variance,
@@ -3918,10 +4221,24 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                             }),
                             amps,
                         );
-                        let (label, conf) = model.classify(&feat_arr);
+                        ns.adaptive_feature_history.push_back(feat_arr);
+                        if ns.adaptive_feature_history.len() > FRAME_HISTORY_CAPACITY {
+                            ns.adaptive_feature_history.pop_front();
+                        }
+
+                        let (label, conf) = model
+                            .classify_temporal(&ns.adaptive_feature_history)
+                            .unwrap_or_else(|| {
+                                model.classify(
+                                    ns.adaptive_feature_history
+                                        .back()
+                                        .expect("feature just pushed"),
+                                )
+                            });
                         classification.motion_level = label.to_string();
                         classification.presence = label != "absent";
-                        classification.confidence = (conf * 0.7 + classification.confidence * 0.3).clamp(0.0, 1.0);
+                        classification.confidence =
+                            (conf * 0.7 + classification.confidence * 0.3).clamp(0.0, 1.0);
                     }
 
                     ns.rssi_history.push_back(features.mean_rssi);
@@ -3929,10 +4246,9 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         ns.rssi_history.pop_front();
                     }
 
-                    let raw_vitals = ns.vital_detector.process_frame(
-                        &frame.amplitudes,
-                        &frame.phases,
-                    );
+                    let raw_vitals = ns
+                        .vital_detector
+                        .process_frame(&frame.amplitudes, &frame.phases);
                     let vitals = smooth_vitals_node(ns, &raw_vitals);
                     ns.latest_vitals = vitals.clone();
 
@@ -3941,7 +4257,8 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     let raw_score = corr_persons as f64 / 3.0;
                     ns.smoothed_person_score = ns.smoothed_person_score * 0.92 + raw_score * 0.08;
                     if classification.presence {
-                        let count = score_to_person_count(ns.smoothed_person_score, ns.prev_person_count);
+                        let count =
+                            score_to_person_count(ns.smoothed_person_score, ns.prev_person_count);
                         ns.prev_person_count = count;
                     } else {
                         ns.prev_person_count = 0;
@@ -3966,46 +4283,85 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     s.tick += 1;
                     let tick = s.tick;
 
-                    let motion_score = if classification.motion_level == "active" { 0.8 }
-                        else if classification.motion_level == "present_still" { 0.3 }
-                        else { 0.05 };
+                    let mut motion_score = if classification.motion_level == "active" {
+                        0.8
+                    } else if classification.motion_level == "present_still" {
+                        0.3
+                    } else if classification.motion_level == "present_moving" {
+                        0.6
+                    } else {
+                        0.05
+                    };
 
-                    // Aggregate person count: gate on presence first (matching WiFi path).
+                    // Aggregate person count: use the independent multistatic/person-count path
+                    // as an absence consensus gate.  A common empty-room failure mode is that
+                    // the adaptive motion classifier over-reports `present_moving` while the
+                    // multistatic fused/person-count signal remains zero.  Do not force a
+                    // minimum count of 1 just because the motion classifier said "present";
+                    // require the independent person-count path to agree.
                     let now = std::time::Instant::now();
                     let total_persons = if classification.presence {
                         let (fused, fallback_count) = multistatic_bridge::fuse_or_fallback(
-                            &s.multistatic_fuser, &s.node_states,
+                            &s.multistatic_fuser,
+                            &s.node_states,
                         );
                         match fused {
                             Some(ref f) => {
-                                let score = multistatic_bridge::compute_person_score_from_amplitudes(&f.fused_amplitude);
-                                s.smoothed_person_score = s.smoothed_person_score * 0.90 + score * 0.10;
+                                let score =
+                                    multistatic_bridge::compute_person_score_from_amplitudes(
+                                        &f.fused_amplitude,
+                                    );
+                                s.smoothed_person_score =
+                                    s.smoothed_person_score * 0.90 + score * 0.10;
                                 let count = s.person_count();
                                 s.prev_person_count = count;
-                                count.max(1)
+                                count
                             }
-                            None => fallback_count.unwrap_or(0).max(1),
+                            None => fallback_count.unwrap_or(0),
                         }
                     } else {
                         s.prev_person_count = 0;
                         0
                     };
 
+                    if classification.presence && total_persons == 0 {
+                        classification.motion_level = "absent".to_string();
+                        classification.presence = false;
+                        classification.confidence = classification.confidence.min(0.35);
+                        motion_score = 0.05;
+                        s.prev_person_count = 0;
+                        if let Some(ns) = s.node_states.get_mut(&node_id) {
+                            ns.current_motion_level = "absent".to_string();
+                            ns.prev_person_count = 0;
+                        }
+                    }
+
                     // Feed field model calibration if active (use per-node history for ESP32).
-                    if let Some(frame_history) = s.node_states.get(&node_id).map(|ns| ns.frame_history.clone()) {
+                    if let Some(frame_history) = s
+                        .node_states
+                        .get(&node_id)
+                        .map(|ns| ns.frame_history.clone())
+                    {
                         if let Some(ref mut fm) = s.field_model {
                             field_bridge::maybe_feed_calibration(fm, &frame_history);
                         }
                     }
 
                     // Build nodes array with all active nodes.
-                    let active_nodes: Vec<NodeInfo> = s.node_states.iter()
-                        .filter(|(_, n)| n.last_frame_time.map_or(false, |t| now.duration_since(t).as_secs() < 10))
+                    let active_nodes: Vec<NodeInfo> = s
+                        .node_states
+                        .iter()
+                        .filter(|(_, n)| {
+                            n.last_frame_time
+                                .map_or(false, |t| now.duration_since(t).as_secs() < 10)
+                        })
                         .map(|(&id, n)| NodeInfo {
                             node_id: id,
                             rssi_dbm: n.rssi_history.back().copied().unwrap_or(0.0),
                             position: [2.0, 0.0, 1.5],
-                            amplitude: n.frame_history.back()
+                            amplitude: n
+                                .frame_history
+                                .back()
                                 .map(|a| a.iter().take(56).cloned().collect())
                                 .unwrap_or_default(),
                             subcarrier_count: n.frame_history.back().map_or(0, |a| a.len()),
@@ -4021,8 +4377,11 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         features: fused_features.clone(),
                         classification,
                         signal_field: generate_signal_field(
-                            fused_features.mean_rssi, motion_score, breathing_rate_hz,
-                            fused_features.variance.min(1.0), &sub_variances,
+                            fused_features.mean_rssi,
+                            motion_score,
+                            breathing_rate_hz,
+                            fused_features.variance.min(1.0),
+                            &sub_variances,
                         ),
                         vital_signs: Some(vitals),
                         enhanced_motion: None,
@@ -4034,7 +4393,11 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         pose_keypoints: None,
                         model_status: None,
                         persons: None,
-                        estimated_persons: if total_persons > 0 { Some(total_persons) } else { None },
+                        estimated_persons: if total_persons > 0 {
+                            Some(total_persons)
+                        } else {
+                            None
+                        },
                         // ADR-084 Pass 3.6: surface per-node novelty_score
                         // (and the rest of the per-node feature snapshot)
                         // on the WebSocket envelope so cluster-Pi consumers
@@ -4046,7 +4409,9 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                     let raw_persons = derive_pose_from_sensing(&update);
                     let mut last_tracker_instant = s.last_tracker_instant.take();
                     let tracked = tracker_bridge::tracker_update(
-                        &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
+                        &mut s.pose_tracker,
+                        &mut last_tracker_instant,
+                        raw_persons,
                     );
                     s.last_tracker_instant = last_tracker_instant;
                     if !tracked.is_empty() {
@@ -4063,11 +4428,16 @@ async fn udp_receiver_task(state: SharedState, udp_port: u16) {
                         let stale = Duration::from_secs(60);
                         let before = s.node_states.len();
                         s.node_states.retain(|_id, ns| {
-                            ns.last_frame_time.map_or(false, |t| now.duration_since(t) < stale)
+                            ns.last_frame_time
+                                .map_or(false, |t| now.duration_since(t) < stale)
                         });
                         let evicted = before - s.node_states.len();
                         if evicted > 0 {
-                            info!("Evicted {} stale node(s), {} active", evicted, s.node_states.len());
+                            info!(
+                                "Evicted {} stale node(s), {} active",
+                                evicted,
+                                s.node_states.len()
+                            );
                         }
                     }
                 }
@@ -4105,21 +4475,24 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
         let (features, mut classification, breathing_rate_hz, sub_variances, raw_motion) =
             extract_features_from_frame(&frame, &s.frame_history, sample_rate_hz);
         smooth_and_classify(&mut s, &mut classification, raw_motion);
-    adaptive_override(&s, &features, &mut classification);
+        adaptive_override(&s, &features, &mut classification);
 
         s.rssi_history.push_back(features.mean_rssi);
         if s.rssi_history.len() > 60 {
             s.rssi_history.pop_front();
         }
 
-        let motion_score = if classification.motion_level == "active" { 0.8 }
-            else if classification.motion_level == "present_still" { 0.3 }
-            else { 0.05 };
+        let motion_score = if classification.motion_level == "active" {
+            0.8
+        } else if classification.motion_level == "present_still" {
+            0.3
+        } else {
+            0.05
+        };
 
-        let raw_vitals = s.vital_detector.process_frame(
-            &frame.amplitudes,
-            &frame.phases,
-        );
+        let raw_vitals = s
+            .vital_detector
+            .process_frame(&frame.amplitudes, &frame.phases);
         let vitals = smooth_vitals(&mut s, &raw_vitals);
         s.latest_vitals = vitals.clone();
 
@@ -4153,8 +4526,11 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
             features: features.clone(),
             classification,
             signal_field: generate_signal_field(
-                features.mean_rssi, motion_score, breathing_rate_hz,
-                features.variance.min(1.0), &sub_variances,
+                features.mean_rssi,
+                motion_score,
+                breathing_rate_hz,
+                features.variance.min(1.0),
+                &sub_variances,
             ),
             vital_signs: Some(vitals),
             enhanced_motion: None,
@@ -4176,7 +4552,11 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
                 None
             },
             persons: None,
-            estimated_persons: if est_persons > 0 { Some(est_persons) } else { None },
+            estimated_persons: if est_persons > 0 {
+                Some(est_persons)
+            } else {
+                None
+            },
             node_features: None,
         };
 
@@ -4184,7 +4564,9 @@ async fn simulated_data_task(state: SharedState, tick_ms: u64) {
         let raw_persons = derive_pose_from_sensing(&update);
         let mut last_tracker_instant = s.last_tracker_instant.take();
         let tracked = tracker_bridge::tracker_update(
-            &mut s.pose_tracker, &mut last_tracker_instant, raw_persons,
+            &mut s.pose_tracker,
+            &mut last_tracker_instant,
+            raw_persons,
         );
         s.last_tracker_instant = last_tracker_instant;
         if !tracked.is_empty() {
@@ -4240,8 +4622,11 @@ async fn main() {
         eprintln!("Running vital sign detection benchmark (1000 frames)...");
         let (total, per_frame) = vital_signs::run_benchmark(1000);
         eprintln!();
-        eprintln!("Summary: {} total, {} per frame",
-            format!("{total:?}"), format!("{per_frame:?}"));
+        eprintln!(
+            "Summary: {} total, {} per frame",
+            format!("{total:?}"),
+            format!("{per_frame:?}")
+        );
         return;
     }
 
@@ -4302,22 +4687,32 @@ async fn main() {
     if args.pretrain {
         eprintln!("=== WiFi-DensePose Contrastive Pretraining (ADR-024) ===");
 
-        let ds_path = args.dataset.clone().unwrap_or_else(|| PathBuf::from("data"));
+        let ds_path = args
+            .dataset
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("data"));
         let source = match args.dataset_type.as_str() {
             "wipose" => dataset::DataSource::WiPose(ds_path.clone()),
             _ => dataset::DataSource::MmFi(ds_path.clone()),
         };
         let pipeline = dataset::DataPipeline::new(dataset::DataConfig {
-            source, ..Default::default()
+            source,
+            ..Default::default()
         });
 
         // Generate synthetic or load real CSI windows
         let generate_synthetic_windows = || -> Vec<Vec<Vec<f32>>> {
-            (0..50).map(|i| {
-                (0..4).map(|a| {
-                    (0..56).map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5).collect()
-                }).collect()
-            }).collect()
+            (0..50)
+                .map(|i| {
+                    (0..4)
+                        .map(|a| {
+                            (0..56)
+                                .map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5)
+                                .collect()
+                        })
+                        .collect()
+                })
+                .collect()
         };
 
         let csi_windows: Vec<Vec<Vec<f32>>> = match pipeline.load() {
@@ -4331,20 +4726,28 @@ async fn main() {
             }
         };
 
-        let n_subcarriers = csi_windows.first()
+        let n_subcarriers = csi_windows
+            .first()
             .and_then(|w| w.first())
             .map(|f| f.len())
             .unwrap_or(56);
 
         let tf_config = graph_transformer::TransformerConfig {
-            n_subcarriers, n_keypoints: 17, d_model: 64, n_heads: 4, n_gnn_layers: 2,
+            n_subcarriers,
+            n_keypoints: 17,
+            d_model: 64,
+            n_heads: 4,
+            n_gnn_layers: 2,
         };
         let transformer = graph_transformer::CsiToPoseTransformer::new(tf_config);
         eprintln!("Transformer params: {}", transformer.param_count());
 
         let trainer_config = trainer::TrainerConfig {
             epochs: args.pretrain_epochs,
-            batch_size: 8, lr: 0.001, warmup_epochs: 2, min_lr: 1e-6,
+            batch_size: 8,
+            lr: 0.001,
+            warmup_epochs: 2,
+            min_lr: 1e-6,
             early_stop_patience: args.pretrain_epochs + 1,
             pretrain_temperature: 0.07,
             ..Default::default()
@@ -4352,12 +4755,18 @@ async fn main() {
         let mut t = trainer::Trainer::with_transformer(trainer_config, transformer);
 
         let e_config = embedding::EmbeddingConfig {
-            d_model: 64, d_proj: 128, temperature: 0.07, normalize: true,
+            d_model: 64,
+            d_proj: 128,
+            temperature: 0.07,
+            normalize: true,
         };
         let mut projection = embedding::ProjectionHead::new(e_config.clone());
         let augmenter = embedding::CsiAugmenter::new();
 
-        eprintln!("Starting contrastive pretraining for {} epochs...", args.pretrain_epochs);
+        eprintln!(
+            "Starting contrastive pretraining for {} epochs...",
+            args.pretrain_epochs
+        );
         let start = std::time::Instant::now();
         for epoch in 0..args.pretrain_epochs {
             let loss = t.pretrain_epoch(&csi_windows, &augmenter, &mut projection, 0.07, epoch);
@@ -4394,8 +4803,11 @@ async fn main() {
                 &proj_weights,
             );
             match builder.write_to_file(save_path) {
-                Ok(()) => eprintln!("RVF saved ({} transformer + {} projection params)",
-                    weights.len(), proj_weights.len()),
+                Ok(()) => eprintln!(
+                    "RVF saved ({} transformer + {} projection params)",
+                    weights.len(),
+                    proj_weights.len()
+                ),
                 Err(e) => eprintln!("Failed to save RVF: {e}"),
             }
         }
@@ -4417,23 +4829,36 @@ async fn main() {
 
         let reader = match RvfReader::from_file(&model_path) {
             Ok(r) => r,
-            Err(e) => { eprintln!("Failed to load model: {e}"); std::process::exit(1); }
+            Err(e) => {
+                eprintln!("Failed to load model: {e}");
+                std::process::exit(1);
+            }
         };
 
         let weights = reader.weights().unwrap_or_default();
         let (embed_config_json, proj_weights) = reader.embedding().unwrap_or_else(|| {
             eprintln!("Warning: no embedding segment in RVF, using defaults");
-            (serde_json::json!({"d_model":64,"d_proj":128,"temperature":0.07,"normalize":true}), Vec::new())
+            (
+                serde_json::json!({"d_model":64,"d_proj":128,"temperature":0.07,"normalize":true}),
+                Vec::new(),
+            )
         });
 
         let d_model = embed_config_json["d_model"].as_u64().unwrap_or(64) as usize;
         let d_proj = embed_config_json["d_proj"].as_u64().unwrap_or(128) as usize;
 
         let tf_config = graph_transformer::TransformerConfig {
-            n_subcarriers: 56, n_keypoints: 17, d_model, n_heads: 4, n_gnn_layers: 2,
+            n_subcarriers: 56,
+            n_keypoints: 17,
+            d_model,
+            n_heads: 4,
+            n_gnn_layers: 2,
         };
         let e_config = embedding::EmbeddingConfig {
-            d_model, d_proj, temperature: 0.07, normalize: true,
+            d_model,
+            d_proj,
+            temperature: 0.07,
+            normalize: true,
         };
         let mut extractor = embedding::EmbeddingExtractor::new(tf_config, e_config.clone());
 
@@ -4450,20 +4875,35 @@ async fn main() {
         }
 
         // Load dataset and extract embeddings
-        let _ds_path = args.dataset.clone().unwrap_or_else(|| PathBuf::from("data"));
-        let csi_windows: Vec<Vec<Vec<f32>>> = (0..10).map(|i| {
-            (0..4).map(|a| {
-                (0..56).map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5).collect()
-            }).collect()
-        }).collect();
+        let _ds_path = args
+            .dataset
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("data"));
+        let csi_windows: Vec<Vec<Vec<f32>>> = (0..10)
+            .map(|i| {
+                (0..4)
+                    .map(|a| {
+                        (0..56)
+                            .map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5)
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect();
 
-        eprintln!("Extracting embeddings from {} CSI windows...", csi_windows.len());
+        eprintln!(
+            "Extracting embeddings from {} CSI windows...",
+            csi_windows.len()
+        );
         let embeddings = extractor.extract_batch(&csi_windows);
         for (i, emb) in embeddings.iter().enumerate() {
             let norm: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
             eprintln!("  Window {i}: {d_proj}-dim embedding, ||e|| = {norm:.4}");
         }
-        eprintln!("Extracted {} embeddings of dimension {d_proj}", embeddings.len());
+        eprintln!(
+            "Extracted {} embeddings of dimension {d_proj}",
+            embeddings.len()
+        );
 
         return;
     }
@@ -4478,7 +4918,10 @@ async fn main() {
             "temporal" => embedding::IndexType::TemporalBaseline,
             "person" => embedding::IndexType::PersonTrack,
             _ => {
-                eprintln!("Unknown index type '{}'. Use: env, activity, temporal, person", index_type_str);
+                eprintln!(
+                    "Unknown index type '{}'. Use: env, activity, temporal, person",
+                    index_type_str
+                );
                 std::process::exit(1);
             }
         };
@@ -4488,11 +4931,17 @@ async fn main() {
         let mut extractor = embedding::EmbeddingExtractor::new(tf_config, e_config);
 
         // Generate synthetic CSI windows for demo
-        let csi_windows: Vec<Vec<Vec<f32>>> = (0..20).map(|i| {
-            (0..4).map(|a| {
-                (0..56).map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5).collect()
-            }).collect()
-        }).collect();
+        let csi_windows: Vec<Vec<Vec<f32>>> = (0..20)
+            .map(|i| {
+                (0..4)
+                    .map(|a| {
+                        (0..56)
+                            .map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5)
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect();
 
         let mut index = embedding::FingerprintIndex::new(index_type);
         for (i, window) in csi_windows.iter().enumerate() {
@@ -4507,7 +4956,10 @@ async fn main() {
         let results = index.search(&query_emb, 5);
         eprintln!("Top-5 nearest to window_0:");
         for r in &results {
-            eprintln!("  entry={}, distance={:.4}, metadata={}", r.entry, r.distance, r.metadata);
+            eprintln!(
+                "  entry={}, distance={:.4}, metadata={}",
+                r.entry, r.distance, r.metadata
+            );
         }
 
         return;
@@ -4518,7 +4970,10 @@ async fn main() {
         eprintln!("=== WiFi-DensePose Training Mode ===");
 
         // Build data pipeline
-        let ds_path = args.dataset.clone().unwrap_or_else(|| PathBuf::from("data"));
+        let ds_path = args
+            .dataset
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("data"));
         let source = match args.dataset_type.as_str() {
             "wipose" => dataset::DataSource::WiPose(ds_path.clone()),
             _ => dataset::DataSource::MmFi(ds_path.clone()),
@@ -4530,25 +4985,31 @@ async fn main() {
 
         // Generate synthetic training data (50 samples with deterministic CSI + keypoints)
         let generate_synthetic = || -> Vec<dataset::TrainingSample> {
-            (0..50).map(|i| {
-                let csi: Vec<Vec<f32>> = (0..4).map(|a| {
-                    (0..56).map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5).collect()
-                }).collect();
-                let mut kps = [(0.0f32, 0.0f32, 1.0f32); 17];
-                for (k, kp) in kps.iter_mut().enumerate() {
-                    kp.0 = (k as f32 * 0.1 + i as f32 * 0.02).sin() * 100.0 + 320.0;
-                    kp.1 = (k as f32 * 0.15 + i as f32 * 0.03).cos() * 80.0 + 240.0;
-                }
-                dataset::TrainingSample {
-                    csi_window: csi,
-                    pose_label: dataset::PoseLabel {
-                        keypoints: kps,
-                        body_parts: Vec::new(),
-                        confidence: 1.0,
-                    },
-                    source: "synthetic",
-                }
-            }).collect()
+            (0..50)
+                .map(|i| {
+                    let csi: Vec<Vec<f32>> = (0..4)
+                        .map(|a| {
+                            (0..56)
+                                .map(|s| ((i * 7 + a * 13 + s) as f32 * 0.31).sin() * 0.5)
+                                .collect()
+                        })
+                        .collect();
+                    let mut kps = [(0.0f32, 0.0f32, 1.0f32); 17];
+                    for (k, kp) in kps.iter_mut().enumerate() {
+                        kp.0 = (k as f32 * 0.1 + i as f32 * 0.02).sin() * 100.0 + 320.0;
+                        kp.1 = (k as f32 * 0.15 + i as f32 * 0.03).cos() * 80.0 + 240.0;
+                    }
+                    dataset::TrainingSample {
+                        csi_window: csi,
+                        pose_label: dataset::PoseLabel {
+                            keypoints: kps,
+                            body_parts: Vec::new(),
+                            confidence: 1.0,
+                        },
+                        source: "synthetic",
+                    }
+                })
+                .collect()
         };
 
         // Load samples (fall back to synthetic if dataset missing/empty)
@@ -4558,7 +5019,10 @@ async fn main() {
                 s
             }
             Ok(_) => {
-                eprintln!("No samples found at {}. Using synthetic data.", ds_path.display());
+                eprintln!(
+                    "No samples found at {}. Using synthetic data.",
+                    ds_path.display()
+                );
                 generate_synthetic()
             }
             Err(e) => {
@@ -4568,17 +5032,21 @@ async fn main() {
         };
 
         // Convert dataset samples to trainer format
-        let trainer_samples: Vec<trainer::TrainingSample> = samples.iter()
-            .map(trainer::from_dataset_sample)
-            .collect();
+        let trainer_samples: Vec<trainer::TrainingSample> =
+            samples.iter().map(trainer::from_dataset_sample).collect();
 
         // Split 80/20 train/val
         let split = (trainer_samples.len() * 4) / 5;
         let (train_data, val_data) = trainer_samples.split_at(split.max(1));
-        eprintln!("Train: {} samples, Val: {} samples", train_data.len(), val_data.len());
+        eprintln!(
+            "Train: {} samples, Val: {} samples",
+            train_data.len(),
+            val_data.len()
+        );
 
         // Create transformer + trainer
-        let n_subcarriers = train_data.first()
+        let n_subcarriers = train_data
+            .first()
             .and_then(|s| s.csi_features.first())
             .map(|f| f.len())
             .unwrap_or(56);
@@ -4608,8 +5076,10 @@ async fn main() {
         eprintln!("Starting training for {} epochs...", args.epochs);
         let result = t.run_training(train_data, val_data);
         eprintln!("Training complete in {:.1}s", result.total_time_secs);
-        eprintln!("  Best epoch: {}, PCK@0.2: {:.4}, OKS mAP: {:.4}",
-            result.best_epoch, result.best_pck, result.best_oks);
+        eprintln!(
+            "  Best epoch: {}, PCK@0.2: {:.4}, OKS mAP: {:.4}",
+            result.best_epoch, result.best_pck, result.best_oks
+        );
 
         // Save checkpoint
         if let Some(ref ckpt_dir) = args.checkpoint_dir {
@@ -4648,8 +5118,11 @@ async fn main() {
             builder.add_vital_config(&VitalSignConfig::default());
             builder.add_weights(&weights);
             match builder.write_to_file(save_path) {
-                Ok(()) => eprintln!("RVF saved ({} params, {} bytes)",
-                    weights.len(), weights.len() * 4),
+                Ok(()) => eprintln!(
+                    "RVF saved ({} params, {} bytes)",
+                    weights.len(),
+                    weights.len() * 4
+                ),
                 Err(e) => eprintln!("Failed to save RVF: {e}"),
             }
         }
@@ -4743,8 +5216,10 @@ async fn main() {
                 Ok(data) => match ProgressiveLoader::new(&data) {
                     Ok(mut loader) => {
                         if let Ok(la) = loader.load_layer_a() {
-                            info!("  Layer A ready: model={} v{} ({} segments)",
-                                  la.model_name, la.version, la.n_segments);
+                            info!(
+                                "  Layer A ready: model={} v{} ({} segments)",
+                                la.model_name, la.version, la.n_segments
+                            );
                         }
                         model_loaded = true;
                         progressive_loader = Some(loader);
@@ -4764,7 +5239,11 @@ async fn main() {
     // Discover model and recording files on startup
     let initial_models = scan_model_files();
     let initial_recordings = scan_recording_files();
-    info!("Discovered {} model files, {} recording files", initial_models.len(), initial_recordings.len());
+    info!(
+        "Discovered {} model files, {} recording files",
+        initial_models.len(),
+        initial_recordings.len()
+    );
 
     let (tx, _) = broadcast::channel::<String>(256);
     let state: SharedState = Arc::new(RwLock::new(AppStateInner {
@@ -4812,11 +5291,17 @@ async fn main() {
         // Training
         training_status: "idle".to_string(),
         training_config: None,
-        adaptive_model: adaptive_classifier::AdaptiveModel::load(&adaptive_classifier::model_path()).ok().map(|m| {
-            info!("Loaded adaptive classifier: {} frames, {:.1}% accuracy",
-                  m.trained_frames, m.training_accuracy * 100.0);
-            m
-        }),
+        adaptive_model:
+            adaptive_classifier::AdaptiveModel::load(&adaptive_classifier::model_path())
+                .ok()
+                .map(|m| {
+                    info!(
+                        "Loaded adaptive classifier: {} frames, {:.1}% accuracy",
+                        m.trained_frames,
+                        m.training_accuracy * 100.0
+                    );
+                    m
+                }),
         node_states: HashMap::new(),
         // Accuracy sprint
         pose_tracker: PoseTracker::new(),
@@ -4829,7 +5314,10 @@ async fn main() {
             if let Some(ref pos_str) = args.node_positions {
                 let positions = field_bridge::parse_node_positions(pos_str);
                 if !positions.is_empty() {
-                    info!("Configured {} node positions for multistatic fusion", positions.len());
+                    info!(
+                        "Configured {} node positions for multistatic fusion",
+                        positions.len()
+                    );
                     fuser.set_node_positions(positions);
                 }
             }
@@ -4858,7 +5346,9 @@ async fn main() {
     }
 
     // ADR-050: Parse bind address once, use for all listeners
-    let bind_ip: std::net::IpAddr = args.bind_addr.parse()
+    let bind_ip: std::net::IpAddr = args
+        .bind_addr
+        .parse()
         .expect("Invalid --bind-addr (use 127.0.0.1 or 0.0.0.0)");
 
     // WebSocket server on dedicated port (8765)
@@ -4869,7 +5359,8 @@ async fn main() {
         .with_state(ws_state);
 
     let ws_addr = SocketAddr::from((bind_ip, args.ws_port));
-    let ws_listener = tokio::net::TcpListener::bind(ws_addr).await
+    let ws_listener = tokio::net::TcpListener::bind(ws_addr)
+        .await
         .expect("Failed to bind WebSocket port");
     info!("WebSocket server listening on {ws_addr}");
 
@@ -4950,20 +5441,23 @@ async fn main() {
         .with_state(state.clone());
 
     let http_addr = SocketAddr::from((bind_ip, args.http_port));
-    let http_listener = tokio::net::TcpListener::bind(http_addr).await
+    let http_listener = tokio::net::TcpListener::bind(http_addr)
+        .await
         .expect("Failed to bind HTTP port");
     info!("HTTP server listening on {http_addr}");
-    info!("Open http://localhost:{}/ui/index.html in your browser", args.http_port);
+    info!(
+        "Open http://localhost:{}/ui/index.html in your browser",
+        args.http_port
+    );
 
     // Run the HTTP server with graceful shutdown support
     let shutdown_state = state.clone();
-    let server = axum::serve(http_listener, http_app)
-        .with_graceful_shutdown(async {
-            tokio::signal::ctrl_c()
-                .await
-                .expect("failed to install CTRL+C handler");
-            info!("Shutdown signal received");
-        });
+    let server = axum::serve(http_listener, http_app).with_graceful_shutdown(async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+        info!("Shutdown signal received");
+    });
 
     server.await.unwrap();
 
@@ -5015,9 +5509,7 @@ mod novelty_tests {
     #[test]
     fn first_frame_yields_max_novelty_then_zero_on_repeat() {
         let mut ns = NodeState::new();
-        let amplitudes: Vec<f64> = (0..NOVELTY_VECTOR_DIM)
-            .map(|i| (i as f64).sin())
-            .collect();
+        let amplitudes: Vec<f64> = (0..NOVELTY_VECTOR_DIM).map(|i| (i as f64).sin()).collect();
 
         ns.update_novelty(&amplitudes);
         let first = ns.last_novelty_score.expect("sketch bank initialised");


### PR DESCRIPTION
## Summary
- Expand adaptive training samples from RuView multi-node JSONL into per-node sequences so runtime per-node classification matches training data shape.
- Preserve temporal window boundaries by grouping training windows by recording/node sequence key instead of concatenating unrelated nodes or captures.
- Add an absence consensus gate: when adaptive motion says present but independent multistatic/person-count fusion remains zero, clamp the fused output and active node API view to `absent` / `person_count: 0`.

## Why
In the current empty-room acceptance case, all six live ESP32 CSI nodes could report `present_moving` while the independent person-count path reported zero people. That creates an empty-room false positive. This PR treats that contradiction as absence unless the independent person-count/fusion path agrees there is a person.

Related: #518, #521

## Local validation
- `cargo fmt --package wifi-densepose-sensing-server`
- `cargo test -p wifi-densepose-sensing-server --bin sensing-server adaptive_classifier::tests -- --nocapture` — 4 passed
- `cargo test -p wifi-densepose-sensing-server --bin sensing-server -- --nocapture` — 74 passed
- `cargo test -p wifi-densepose-sensing-server` — passed
- `docker compose -f docker/docker-compose.yml up -d --build sensing-server` — rebuilt/restarted
- Live empty-room check after rebuild: final `/api/v1/sensing/latest` reported `motion_level: absent`, `presence: false`, `estimated_persons: null`; final `/api/v1/nodes` sample showed all six active nodes as `absent` with `person_count: 0`.

## Notes
This is intentionally focused on sensing-server adaptive/runtime behavior. It does not include local recordings, generated model files, firmware binaries, or unrelated local worktree changes.
