### PR TITLE
ci: fix "Update vendor submodules" workflow (git identity + drop --merge)

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -19,8 +19,24 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update submodules to latest main
-        run: git submodule update --remote --merge
+      # Identity must be set BEFORE any operation that can create a commit.
+      # `git submodule update --remote --merge` used to fail here with
+      # "Committer identity unknown" because the merge inside vendor/ruvector
+      # needs an author when the pinned commit isn't a fast-forward of upstream.
+      - name: Configure git identity
+        run: |
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # Use a plain `--remote` checkout (detached HEAD at each submodule's
+      # configured `branch` tip from .gitmodules) rather than `--merge`. We only
+      # want to bump the superproject's gitlink to the latest upstream commit;
+      # there's no reason to create merge commits inside the vendored repos, and
+      # `--merge` breaks whenever the current pin has diverged from that branch.
+      - name: Update submodules to latest tracked branch
+        run: |
+          git submodule sync --recursive
+          git submodule update --remote --recursive
 
       - name: Check for changes
         id: check
@@ -29,21 +45,22 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "--- submodule pointer changes ---"
+            git submodule status --recursive || true
+            git diff --submodule=log -- vendor/ || true
           fi
 
       - name: Create PR with updates
         if: steps.check.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           BRANCH="chore/update-submodules-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
           git add vendor/
-          git commit -m "chore: update vendor submodules to latest main"
+          git commit -m "chore: update vendor submodules to latest upstream"
           git push origin "$BRANCH"
           gh pr create \
             --title "chore: update vendor submodules" \
-            --body "Automated submodule update to latest upstream main." \
+            --body "Automated submodule update to the latest upstream commit on each submodule's tracked branch (see \`.gitmodules\`). Review the pointer diff before merging." \
             --base main \
             --head "$BRANCH"
         env:


### PR DESCRIPTION
The scheduled `Update vendor submodules` job has failed on every run for days:

```
fatal: empty ident name (...) not allowed
fatal: Unable to merge '...' in submodule path 'vendor/ruvector'
```

**Root cause (two bugs):**
1. `git config user.name/email` was only set inside the *Create PR* step, but `git submodule update --remote --merge` runs first; the merge inside `vendor/ruvector` needs a committer when the pinned commit isn't a fast-forward of upstream `main` → *Committer identity unknown*.
2. `--merge` is the wrong op — we only want to bump the superproject gitlink to the latest upstream commit on each submodule's tracked branch; there's no reason to create merge commits inside the vendored repos, and `--merge` breaks whenever the current pin has diverged (which `vendor/ruvector`'s does — it's on a `ruvllm-pi-cluster-*` tag, not `main`).

**Fix:**
- Add a `Configure git identity` step before any commit-creating op.
- `git submodule update --remote --merge` → `git submodule sync --recursive && git submodule update --remote --recursive` (detached checkout at each `.gitmodules` branch tip).
- Log the submodule pointer diff in *Check for changes* for reviewability.
- Tidy the PR-creation step.

Note: with `--remote`, the next successful run will propose bumping `vendor/ruvector` from its current `ruvllm-pi-cluster-*` pin to `origin/main` HEAD (since `.gitmodules` declares `branch = main` for it). If that pin is intentional, change `.gitmodules` or exclude it from the loop — flagging so it's a conscious choice.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)