### PR TITLE
fix(docs): correct 92.9% PCK@20 overclaim + RuView training-pipeline audit (7 findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **README: corrected the camera-supervised pose-accuracy claim.** The README stated
+  "92.9% PCK@20" for camera-supervised training; that figure does not appear in
+  ADR-079 and is ~2.6× the ADR's own success target (>35% PCK@20). ADR-079 phases
+  P7 (data collection), P8 (training + evaluation on real paired data) and P9
+  (cross-room LoRA) are still `Pending`, so no measured camera-supervised PCK@20 has
+  been published. README now states the proxy-supervised baseline (≈2.5%) and the
+  ADR-079 target (35%+), and notes the eval phases are pending. Surfaced by the
+  PowerPlatePulse training-pipeline audit (2026-05-11); 6 remaining audit findings
+  tracked in the PR.
+
 ### Added
 - **`nvsim` crate — deterministic NV-diamond magnetometer pipeline simulator** (ADR-089) —
   New standalone leaf crate at `v2/crates/nvsim` modeling a forward-only

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > **Beta Software** — Under active development. APIs and firmware may change. Known limitations:
 > - ESP32-C3 and original ESP32 are not supported (single-core, insufficient for CSI DSP)
 > - Single ESP32 deployments have limited spatial resolution — use 2+ nodes or add a [Cognitum Seed](https://cognitum.one) for best results
-> - Camera-free pose accuracy is limited — use [camera ground-truth training](docs/adr/ADR-079-camera-ground-truth-training.md) for 92.9% PCK@20
+> - Camera-free pose accuracy is limited (PCK@20 ≈ 2.5% with proxy labels) — [camera ground-truth training](docs/adr/ADR-079-camera-ground-truth-training.md) targets **35%+ PCK@20**; the pipeline is implemented, but the data-collection and evaluation phases (ADR-079 P7–P9) are still pending, so no measured camera-supervised PCK@20 has been published yet
 >
 > Contributions and bug reports welcome at [Issues](https://github.com/ruvnet/RuView/issues).
 
@@ -56,7 +56,7 @@ RuView also supports pose estimation (17 COCO keypoints via the WiFlow architect
 > | 🧱 **Through-wall** | Fresnel zone geometry + multipath modeling | Up to 5m depth |
 > | 🧠 **Edge intelligence** | 8-dim feature vectors + RVF store on Cognitum Seed | $140 total BOM |
 > | 🎯 **Camera-free training** | 10 sensor signals, no labels needed | 84s on M4 Pro |
-> | 📷 **Camera-supervised training** | MediaPipe + ESP32 CSI → 92.9% PCK@20 | 19 min on laptop |
+> | 📷 **Camera-supervised training** | MediaPipe + ESP32 CSI → **35%+ PCK@20 target** (ADR-079; eval phases pending) | ~19 min on laptop (pipeline) |
 > | 📡 **Multi-frequency mesh** | Channel hopping across 6 bands, neighbor APs as illuminators | 3x sensing bandwidth |
 > | 🌐 **3D point cloud** *(optional fusion)* | Camera depth (MiDaS) + WiFi CSI + mmWave radar → unified spatial model | 22 ms pipeline · 19K+ points/frame |
 


### PR DESCRIPTION
## Summary

Corrects an unsubstantiated accuracy claim and records the findings of the **PowerPlatePulse training-pipeline audit (2026-05-11)** (Stuart Kerr's Stage-A audit, re-verified against `ruvnet/RuView` at `df9d3b0e`).

**This PR fixes finding #5** (the egregious one) and lists the other 6 for follow-up.

## What's fixed here (#5 — README overclaim)

`README.md` claimed **"92.9% PCK@20"** for camera-supervised pose training (lines 12 and 59). That figure:
- appears **nowhere in ADR-079** (the source ADR for this pipeline);
- is **~2.6× ADR-079's own success target** — ADR-079 §"Success Metrics" sets `PCK@20 > 35%`;
- has **no measured backing** — ADR-079 phases **P7** (data collection), **P8** (training + evaluation on real paired data) and **P9** (cross-room LoRA) are all `Pending`.

README now states the proxy-supervised baseline (≈2.5%, per ADR-079) and the ADR-079 target (35%+), and notes the eval phases are pending. CHANGELOG updated.

## The full audit — 7 findings (verified)

| # | Finding | Status / verification |
|---|---|---|
| 1 | **Vitals bandpass features absent from training** | `wifi-densepose-train/src/dataset.rs` feeds raw CSI amplitude/phase only; the breathing/HR bandpass path is not in the training feature set. `wifi-densepose-signal` exposes `bvp`, `features`, `csi_processor` — unused by training. *Confirmed.* → needs implementation |
| 2 | **`wifi-densepose-signal` is a ghost Cargo dep** | Listed in `wifi-densepose-train/Cargo.toml` but `grep -r wifi_densepose_signal v2/crates/wifi-densepose-train/src/` → nothing. Compiled, never imported. *Confirmed.* → wire it (per #1) or drop it |
| 3 | **PIR + BME280 in MODEL_CARD have no implementation** | `docs/huggingface/MODEL_CARD.md` describes PIR/BME280 on the Cognitum Seed as the fine-tuning ground-truth source; no corresponding code in `wifi-densepose-train`. *Partially confirmed — design intent in the card; not implemented in this repo.* → implement or mark as design-only |
| 4 | **`proof.rs` uses `SyntheticCsiDataset` only** | `wifi-densepose-train/src/proof.rs` builds a fixed-seed `SyntheticCsiDataset` for the deterministic proof. *Confirmed* — **but** a deterministic proof *must* use a reproducible source; the real gap is that nothing smoke-tests the real `.npy` `CsiDataset` loader. → add a small real-fixture loader test *alongside* the synthetic proof (don't replace it) |
| 5 | **README claims 92.9% PCK@20 — unsubstantiated** | See above. **✅ Fixed in this PR.** |
| 6 | **CSI format default = 56 subcarriers / 1 NIC** | `wifi-densepose-train/src/config.rs` defaults `num_subcarriers: 56`, `native_subcarriers: 114` (MM-Fi). Multi-node HT40 captures (192 subcarriers / 3 nodes) *are* supported via `native_subcarriers`, but there's no documented mesh preset. → add a `TrainingConfig` mesh preset + docs |
| 7 | **Multi-band 168-subcarrier mesh not in training config** | Related to #6; no preset/example for the ADR-078 multi-frequency mesh case, and the dataset loader assumes ≤2 NICs in its example shapes. → preset constructor + loader handling for >2 NICs |

Provenance: `RUVIEW-TRAINING-AUDIT-2026-05-11.md` + QA (PowerPlatePulse `Docs/Reference/`), independently re-verified against this repo's source.

## Follow-up

#1, #2, #4, #6, #7 are real implementation work (not doc fixes) — recommend splitting into separate issues/PRs. #3 needs a decision (implement the env-sensor ground-truth path, or mark the MODEL_CARD section as design-only). Happy to take them one at a time.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)