### PR TITLE
chore(vendor): add rvcsi as a vendor submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = vendor/sublinear-time-solver
 	url = https://github.com/ruvnet/sublinear-time-solver
 	branch = main
+[submodule "vendor/rvcsi"]
+	path = vendor/rvcsi
+	url = https://github.com/ruvnet/rvcsi
+	branch = main


### PR DESCRIPTION
rvCSI (the edge RF sensing runtime — `v2/crates/rvcsi-*`, ADR-095/096, merged in #542) now has a standalone home: **https://github.com/ruvnet/rvcsi** — 9 crates on crates.io (`rvcsi-core`/`-dsp`/`-events`/`-adapter-file`/`-adapter-nexmon`/`-ruvector`/`-runtime`/`-node`/`-cli`), `@ruv/rvcsi` on npm, plus a Claude Code plugin marketplace.

This PR vendors it under `vendor/rvcsi`, matching the existing `vendor/ruvector` / `vendor/midstream` / `vendor/sublinear-time-solver` pattern. Pure addition — the inline `v2/crates/rvcsi-*` copies are untouched.

**Follow-up (separate PR):** re-point the `v2` Cargo workspace at `vendor/rvcsi/crates/rvcsi-*` and drop the inline copies so rvCSI lives in one place.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)